### PR TITLE
Gave sliding panel dropdowns unique id's to allow for label translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.16.0 (April 7, 2017)
+
+## Breaking Change
+
+- Updated Sliding Panel Dropdown to take mandatory id to allow for label translations.
+
 # 0.15.3 (March 31, 2017)
 
 ## Bugfixes

--- a/packages/visual-stack-docs/src/containers/Components/Docs/slidingpanel.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/slidingpanel.js
@@ -125,7 +125,17 @@ class VSRSlidingPanelDemo extends React.Component {
                         reduxified sliding panel header
                       </SlidingPanelHeader>
                       <VSRSlidingPanelDropdown
+                        id="id1"
                         label="My Redux CIDs"
+                        >
+                        <MultiSelectFilter
+                          values={this.state.companies}
+                          onFilterChange={val => console.log(val)}
+                        />
+                      </VSRSlidingPanelDropdown>
+                      <VSRSlidingPanelDropdown
+                        id="id2"
+                        label="My Other Redux CIDs"
                         >
                         <MultiSelectFilter
                           values={this.state.companies}

--- a/packages/visual-stack-redux/src/components/SlidingPanel.js
+++ b/packages/visual-stack-redux/src/components/SlidingPanel.js
@@ -69,12 +69,12 @@ export class InternalSlidingPanelDropdown extends Component {
     super(props);
   }
   render() {
-    const expanded = R.view(R.lensPath([this.props.label, 'expanded']), this.props.slidingPanel);
+    const expanded = R.view(R.lensPath([this.props.id, 'expanded']), this.props.slidingPanel);
     return (
       <BaseSlidingPanelDropdown
         label={this.props.label}
         expanded={expanded}
-        onClick={() => this.props.toggleFilterDropdown(this.props.label)}
+        onClick={() => this.props.toggleFilterDropdown(this.props.id)}
         >
         { this.props.children }
       </BaseSlidingPanelDropdown>

--- a/packages/visual-stack-redux/src/components/SlidingPanel.js
+++ b/packages/visual-stack-redux/src/components/SlidingPanel.js
@@ -64,6 +64,7 @@ export class InternalToggleIcon extends Component {
 export class InternalSlidingPanelDropdown extends Component {
   static propTypes = {
     slidingPanel: PropTypes.object,
+    id: PropTypes.string.isRequired,
   };
   constructor(props) {
     super(props);

--- a/packages/visual-stack/src/components/SlidingPanel.js
+++ b/packages/visual-stack/src/components/SlidingPanel.js
@@ -43,7 +43,7 @@ export const SlidingPanelDropdown = ({ label, children, onClick, expanded }) => 
   const containerClasses = classNames('filter-container', { expanded });
   const optionsClasses = classNames('filter-options', { expanded });
   return (
-    <li className={containerClasses}>
+    <ul className={containerClasses}>
       <a className="filter-container-label" onClick={onClick}>
         <div>{ label }</div>
         <i className="fa fa-chevron-left"></i>
@@ -53,7 +53,7 @@ export const SlidingPanelDropdown = ({ label, children, onClick, expanded }) => 
           { children }
         </div>
       </ul>
-    </li>
+    </ul>
   );
 };
 


### PR DESCRIPTION
Fixed a bug where redux could not assign a unique id for a sliding panel dropdown due to translation issue. Now when creating a sliding panel dropdown, a unique id must be supplied. 