### PR TITLE
Sliding Panel should shift down.

### DIFF
--- a/packages/visual-stack/src/components/SlidingPanel.css
+++ b/packages/visual-stack/src/components/SlidingPanel.css
@@ -6,7 +6,7 @@
   height: 100%;
   position: fixed;
   right: -250px;
-  top: 50px;
+  top: 109px;
   z-index: 200;
   padding: 0;
   transform: translateX(0);


### PR DESCRIPTION
Sliding Panel should shift down lower to not block header title in App Layout.