### PR TITLE
Side nav fixes

### DIFF
--- a/packages/visual-stack-docs/src/containers/App/SideNav.js
+++ b/packages/visual-stack-docs/src/containers/App/SideNav.js
@@ -2,8 +2,7 @@ import React from 'react';
 import R from 'ramda';
 import { Link } from 'react-router';
 import CJLogo from '@cjdev/visual-stack/lib/components/CJLogo';
-import { LinkContentWrapper } from '@cjdev/visual-stack/lib/components/SideNav';
-import { SideNav, Link as SideNavLink, LinkGroup } from '@cjdev/visual-stack-redux/lib/components/SideNav';
+import { SideNav, Link as SideNavLink, LinkGroup, LinkContentWrapper } from '@cjdev/visual-stack-redux/lib/components/SideNav';
 import { routeComponentMap } from '../Components/Docs/';
 
 import LayoutIcon from 'mdi-react/TelevisionGuideIcon';

--- a/packages/visual-stack-redux/src/components/SideNav.js
+++ b/packages/visual-stack-redux/src/components/SideNav.js
@@ -3,12 +3,11 @@ import R from 'ramda';
 import { connect } from 'react-redux';
 import {
   SideNav as BaseSideNav,
-  Header as BaseHeader,
-  SideNavIcon as BaseIcon,
-  Link as BaseLink,
   LinkGroup as BaseLinkGroup,
 } from '@cjdev/visual-stack/lib/components/SideNav';
 import { toggleSideNavLinkGroup, toggleSideNav } from '../actions';
+
+export { LinkContentWrapper, SideNavIcon, Link, Header } from '@cjdev/visual-stack/lib/components/SideNav';
 
 export class InternalSideNav extends Component {
   static propTypes = {
@@ -61,7 +60,4 @@ const mapState = state => ({ linkGroups: state.visualStack.sideNav.linkGroups })
 export const LinkGroup = connect(mapState, { toggleSideNavLinkGroup })(InternalLinkGroup);
 
 
-export const Header = BaseHeader;
-export const Link = BaseLink;
-export const SideNavIcon = BaseIcon;
 

--- a/packages/visual-stack/src/components/SideNav.css
+++ b/packages/visual-stack/src/components/SideNav.css
@@ -116,6 +116,10 @@
   cursor: pointer;
 }
 
+.sidenav-container-label {
+  white-space: nowrap;
+}
+
 .sidenav .expanded .sidenav-container-label,
 .sidenav .expanded>a {
   background-color: #506b86;


### PR DESCRIPTION
2 small changes following on from version 1.2.0.

* Fix SideNav entries such that they do not wrap during the collapse animation.
* Re-export the LinkContentWrapper through visual-stack-redux such that consuming applications do not have to reference both 'visual-stack' and 'visual-stack-redux' to use the SideNav.