### PR TITLE
Migrate from React.PropTypes to prop-types lib

### DIFF
--- a/packages/visual-stack-redux/package.json
+++ b/packages/visual-stack-redux/package.json
@@ -56,6 +56,7 @@
     "jsdom-global": "^1.7.0",
     "mocha": "^2.4.5",
     "prettier": "^1.7.0",
+    "prop-types": "^15.6.0",
     "react": "^15.6.1",
     "react-addons-test-utils": "^15.6.0",
     "react-dom": "^15.6.1",

--- a/packages/visual-stack-redux/src/components/MenuBar.js
+++ b/packages/visual-stack-redux/src/components/MenuBar.js
@@ -1,5 +1,6 @@
 import { omit } from 'ramda';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 import { MenuBar as Base } from '@cjdev/visual-stack';

--- a/packages/visual-stack-redux/src/components/SideNav/LinkGroup.js
+++ b/packages/visual-stack-redux/src/components/SideNav/LinkGroup.js
@@ -1,5 +1,6 @@
 /** @prettier */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import R from 'ramda';
 import { connect } from 'react-redux';
 import { toggleSideNavLinkGroup, toggleSideNav } from '../../actions';

--- a/packages/visual-stack-redux/src/components/SideNav/SideNav.js
+++ b/packages/visual-stack-redux/src/components/SideNav/SideNav.js
@@ -1,5 +1,6 @@
 /** @prettier */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { LogoutLink, SideNav as BaseSideNav, UserIcon } from '@cjdev/visual-stack/lib/components/SideNav';
 import { LinkGroup } from './LinkGroup';

--- a/packages/visual-stack-redux/src/components/SlidingPanel.js
+++ b/packages/visual-stack-redux/src/components/SlidingPanel.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import R from 'ramda';
 import { connect } from 'react-redux';
 import {

--- a/packages/visual-stack/package.json
+++ b/packages/visual-stack/package.json
@@ -62,6 +62,7 @@
     "mocha": "^2.4.5",
     "postcss-loader": "^1.2.2",
     "prettier": "^1.7.0",
+    "prop-types": "^15.6.0",
     "ramda": "^0.19.1",
     "react": "^15.6.1",
     "react-addons-test-utils": "^15.6.0",

--- a/packages/visual-stack/src/components/BlankSlate.js
+++ b/packages/visual-stack/src/components/BlankSlate.js
@@ -1,7 +1,7 @@
-import './BlankSlate.css';
-
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Button as BaseButton } from './Button';
+import './BlankSlate.css';
 
 export const Wrapper = ({ children, title, subTitle, subTitle2, bubbleImg }) => {
   const imgSrc = bubbleImg || require('../images/visual-stack/default-list-bs-img.png');

--- a/packages/visual-stack/src/components/Button.js
+++ b/packages/visual-stack/src/components/Button.js
@@ -1,7 +1,7 @@
-import './Button.css';
-
+import React from 'react';
+import PropTypes from 'prop-types';
 import { concat, reduce, unapply } from 'ramda';
-import React, { PropTypes } from 'react';
+import './Button.css';
 
 const concatAll = unapply(reduce(concat, []));
 

--- a/packages/visual-stack/src/components/CJLogo.js
+++ b/packages/visual-stack/src/components/CJLogo.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactSVG from 'react-svg';
 import classNames from 'classnames';
 import logoSvg from '../../src/images/ui-kit/new-cj-logo-icon.svg';
@@ -11,7 +12,7 @@ const CJLogo = ({ className }) =>
   />;
 
 CJLogo.propTypes = {
-  className: React.PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default CJLogo;

--- a/packages/visual-stack/src/components/Filters.js
+++ b/packages/visual-stack/src/components/Filters.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import './Filters.css';
 import R from 'ramda';
+import './Filters.css';
 
 export const MultiSelectFilter = ({ values, onFilterChange, selectAllCheckbox, defaultChecked }) => {
   const domCheckboxes = [];

--- a/packages/visual-stack/src/components/Form.js
+++ b/packages/visual-stack/src/components/Form.js
@@ -1,6 +1,6 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import './Form.css';
-
-import React, { PropTypes } from 'react';
 
 export const Input = ({ className, type, ...otherProps }) =>
   <input

--- a/packages/visual-stack/src/components/List.js
+++ b/packages/visual-stack/src/components/List.js
@@ -1,7 +1,8 @@
-import './List.css';
-
+import React from 'react';
+import PropTypes from 'prop-types';
 import { map, omit } from 'ramda';
-import React, { PropTypes } from 'react';
+
+import './List.css';
 
 export const List = ({ children }) =>
   <div>{children}</div>;
@@ -21,9 +22,9 @@ export const ActionButton = ({ icon, className, onClick }) => {
   );
 };
 ActionButton.propTypes = {
-  icon: React.PropTypes.string.isRequired,
-  className: React.PropTypes.string,
-  onClick: React.PropTypes.func.isRequired,
+  icon: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  onClick: PropTypes.func.isRequired,
 };
 ActionButton.defaultProps = {
   className: '',

--- a/packages/visual-stack/src/components/MenuBar.js
+++ b/packages/visual-stack/src/components/MenuBar.js
@@ -1,7 +1,7 @@
-import './MenuBar.css';
-
-import React, { PropTypes, createElement } from 'react';
+import React, { createElement } from 'react';
+import PropTypes from 'prop-types';
 import { always } from 'ramda';
+import './MenuBar.css';
 
 export const MenuBarItem = ({ children }) =>
   <li>

--- a/packages/visual-stack/src/components/Modal.js
+++ b/packages/visual-stack/src/components/Modal.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export const Modal = ({ children }) =>
    <div className="modal" style={{ display: 'block' }}>

--- a/packages/visual-stack/src/components/Panel.js
+++ b/packages/visual-stack/src/components/Panel.js
@@ -1,6 +1,6 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import './Panel.css';
-
-import React, { PropTypes } from 'react';
 
 export const Panel = ({ children }) =>
   <div className="cj-panel panel panel-default">

--- a/packages/visual-stack/src/components/SideNav/Header.js
+++ b/packages/visual-stack/src/components/SideNav/Header.js
@@ -1,5 +1,6 @@
 /** @prettier */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export const Header = ({ children }) => (
   <li className="sidenav-entry sidenav-header">{children}</li>

--- a/packages/visual-stack/src/components/SideNav/LinkGroup.js
+++ b/packages/visual-stack/src/components/SideNav/LinkGroup.js
@@ -1,5 +1,6 @@
 /** @prettier */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import R from 'ramda';
 
 import { SideNavSvgIcon, makeDefaultIcon } from './Icons';

--- a/packages/visual-stack/src/components/SideNav/SideNav.js
+++ b/packages/visual-stack/src/components/SideNav/SideNav.js
@@ -1,5 +1,6 @@
 /** @prettier */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import MediaQuery from 'react-responsive';
 import R from 'ramda';
 

--- a/packages/visual-stack/src/components/SlidingPanel.js
+++ b/packages/visual-stack/src/components/SlidingPanel.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import './SlidingPanel.css';
 
@@ -14,7 +15,7 @@ export const ToggleIcon = ({ onClick, hoverText, toggleIconState }) => {
   );
 };
 ToggleIcon.propTypes = {
-  onClick: React.PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
 };
 
 export const SlidingPanelHeader = ({ children }) => {
@@ -62,5 +63,5 @@ export const SlidingPanelDropdown = ({ label, children, onClick, expanded }) => 
 };
 
 SlidingPanel.propTypes = {
-  active: React.PropTypes.bool,
+  active: PropTypes.bool,
 };

--- a/packages/visual-stack/src/components/Spinner.js
+++ b/packages/visual-stack/src/components/Spinner.js
@@ -1,6 +1,6 @@
-import './spinner.css';
-
 import React from 'react';
+import PropTypes from 'prop-types';
+import './spinner.css';
 
 const Spinner = ({ size, ...propsToPassOn }) => {
   const className = `spinner spinner-${size || 'small'}`;
@@ -13,7 +13,7 @@ const Spinner = ({ size, ...propsToPassOn }) => {
 };
 
 Spinner.propTypes = {
-  size: React.PropTypes.oneOf(['small', 'large', 'extra-large', 'button']),
+  size: PropTypes.oneOf(['small', 'large', 'extra-large', 'button']),
 };
 
 export default Spinner;


### PR DESCRIPTION
In preparation for a React 16 upgrade, this PR migrates all our usage of PropTypes from React to the prop-types library