### PR TITLE
Table component improvements

### DIFF
--- a/packages/visual-stack-docs/src/containers/Components/Docs/table.css
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/table.css
@@ -1,0 +1,27 @@
+.custom-table {
+}
+
+.custom-th {
+  background-color: #369;
+  color: #eee;
+}
+
+.custom-tr td:nth-child(5) {
+  color: red;
+  background-color: rgba(255,0,0,.2)
+}
+
+.custom-td {
+  background-color: #eee;
+  color: #369;
+}
+
+.custom-table-container {
+  padding-top: 40px;
+
+}
+
+.custom-table-title {
+  color: #369;
+}
+

--- a/packages/visual-stack-docs/src/containers/Components/Docs/table.css
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/table.css
@@ -1,14 +1,15 @@
-.custom-table {
+.custom-table-title {
+  color: #369;
 }
 
 .custom-th {
-  background-color: #369;
+  background-color: #69c;
   color: #eee;
 }
 
 .custom-tr td:nth-child(5) {
-  color: red;
-  background-color: rgba(255,0,0,.2)
+  background-color: #69c;
+  color: #eee;
 }
 
 .custom-td {
@@ -16,12 +17,15 @@
   color: #369;
 }
 
-.custom-table-container {
-  padding-top: 40px;
-
+.custom-td-colspan {
+  background-color: #eee;
+  border: 1px solid #ddd;
 }
 
-.custom-table-title {
-  color: #369;
+.custom-td-rowspan {
+  background-color: #69c;
+  color: #eee;
+  border: 1px solid #ddd;
 }
+
 

--- a/packages/visual-stack-docs/src/containers/Components/Docs/table.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/table.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { Panel, Body, Header } from '@cjdev/visual-stack/lib/components/Panel';
 import { Demo, Snippet } from '../../../components/Demo';
 /* s1:start */
-import { Table, TableContainer, Th, Tr, Td, TdRight, TableTitle, TrHead } from '@cjdev/visual-stack/lib/components/Table';
+import { Table, TableContainer, Th, Tr, Td, TableTitle, TrHead } from '@cjdev/visual-stack/lib/components/Table';
+import './table.css';
 /* s1:end */
 
 export default () =>
@@ -16,33 +17,34 @@ export default () =>
             </Header>
             <Body>
             { /* s2:start */ }
-            <TableContainer>
-              <TableTitle>Title of your Table</TableTitle>
-              <Table>
+            <TableContainer className="custom-table-container">
+              <div>Custom container with a extra top padding</div>
+              <TableTitle className="custom-table-title">Title Table</TableTitle>
+              <Table className="custom-table">
                 <TrHead>
                     <Th>Header Section 1</Th>
                     <Th>Header Section 2</Th>
                     <Th>Header Section 3</Th>
                     <Th>Header Section 4</Th>
                     <Th>Header Section 5</Th>
-                    <Th>Header Section 6</Th>
+                    <Th className="custom-th">Header with className</Th>
                 </TrHead>
                 <tbody>
                   <Tr>
-                    <TdRight>1</TdRight>
+                    <Td>1</Td>
                     <Td>2</Td>
                     <Td>3</Td>
                     <Td>4</Td>
                     <Td>5</Td>
-                    <Td>6</Td>
+                    <Td className="custom-td">Cell with className</Td>
                   </Tr>
-                  <Tr>
+                  <Tr className="custom-tr">
                     <Td>no</Td>
                     <Td>yes</Td>
                     <Td>no</Td>
                     <Td>yes</Td>
-                    <Td>no</Td>
-                    <Td>yes</Td>
+                    <Td>with className on Row</Td>
+                    <Td right className="custom-td">Right aligned with className</Td>
                   </Tr>
                 </tbody>
               </Table>

--- a/packages/visual-stack-docs/src/containers/Components/Docs/table.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/table.js
@@ -1,60 +1,310 @@
+/** @prettier */
 import React from 'react';
 import { Panel, Body, Header } from '@cjdev/visual-stack/lib/components/Panel';
 import { Demo, Snippet } from '../../../components/Demo';
 /* s1:start */
-import { Table, TableContainer, Th, Tr, Td, TableTitle, TrHead } from '@cjdev/visual-stack/lib/components/Table';
-import './table.css';
+import {
+  TableContainer,
+  TableTitle,
+  Table,
+  THead,
+  TBody,
+  TFoot,
+  Tr,
+  Th,
+  Td,
+} from '@cjdev/visual-stack/lib/components/Table';
+import './table.css'; // for custom styles
 /* s1:end */
 
-export default () =>
-    <Demo srcFile="/samples/src/containers/Components/Docs/table.js">
-    { snippets => {
+export default () => (
+  <Demo srcFile="/samples/src/containers/Components/Docs/table.js">
+    {snippets => {
       return (
         <div>
           <Panel>
+            <Header>Simple Table</Header>
+            <Body>
+              <div className="docs">The basics.</div>
+              {/* s2:start */}
+              <TableContainer>
+                <TableTitle>Table Title</TableTitle>
+                <Table>
+                  <THead>
+                    <Tr>
+                      <Th>Header 1</Th>
+                      <Th>Header 2</Th>
+                      <Th>Header 3</Th>
+                    </Tr>
+                  </THead>
+                  <TBody>
+                    <Tr>
+                      <Td>1</Td>
+                      <Td>2</Td>
+                      <Td>3</Td>
+                    </Tr>
+                    <Tr>
+                      <Td>1</Td>
+                      <Td>2</Td>
+                      <Td>3</Td>
+                    </Tr>
+                  </TBody>
+                  <TFoot>
+                    <Tr>
+                      <Th>Footer Section 1</Th>
+                      <Th>Footer Section 2</Th>
+                      <Th>Footer Section 3</Th>
+                    </Tr>
+                  </TFoot>
+                </Table>
+              </TableContainer>
+              {/* s2:end */}
+              <Snippet tag="s1" src={snippets} />
+              <Snippet tag="s2" src={snippets} />
+            </Body>
+          </Panel>
+
+          <Panel>
+            <Header>HTML Table Props and className</Header>
+            <Body>
+              <div className="docs">
+                All components accept valid DOM props and a{' '}
+                <code>className</code> for application-specific styling.
+              </div>
+              {/* s3:start */}
+              <TableContainer>
+                <TableTitle>Table Title</TableTitle>
+                <Table>
+                  <THead>
+                    <Tr>
+                      <Th>Header 1</Th>
+                      <Th>Header 2</Th>
+                      <Th>Header 3</Th>
+                    </Tr>
+                  </THead>
+                  <TBody>
+                    <Tr>
+                      <Td className="custom-td-colspan" colSpan={2}>
+                        1 (colSpan 2)
+                      </Td>
+                      <Td className="custom-td-rowspan" rowSpan={2}>
+                        3 (rowSpan 2)
+                      </Td>
+                    </Tr>
+                    <Tr>
+                      <Td>1</Td>
+                      <Td>2</Td>
+                    </Tr>
+                  </TBody>
+                  <TFoot>
+                    <Tr>
+                      <Th>Footer Section 1</Th>
+                      <Th>Footer Section 2</Th>
+                      <Th>Footer Section 3</Th>
+                    </Tr>
+                  </TFoot>
+                </Table>
+              </TableContainer>
+              {/* s3:end */}
+              <Snippet tag="s3" src={snippets} />
+            </Body>
+          </Panel>
+
+          <Panel>
             <Header>
-              Simple Table Example
+              Cells with <code>nowrap</code>
             </Header>
             <Body>
-            { /* s2:start */ }
-            <TableContainer className="custom-table-container">
-              <div>Custom container with a extra top padding</div>
-              <TableTitle className="custom-table-title">Title Table</TableTitle>
-              <Table className="custom-table">
-                <TrHead>
-                    <Th>Header Section 1</Th>
-                    <Th>Header Section 2</Th>
-                    <Th>Header Section 3</Th>
-                    <Th>Header Section 4</Th>
-                    <Th>Header Section 5</Th>
-                    <Th className="custom-th">Header with className</Th>
-                </TrHead>
-                <tbody>
-                  <Tr>
-                    <Td>1</Td>
-                    <Td>2</Td>
-                    <Td>3</Td>
-                    <Td>4</Td>
-                    <Td>5</Td>
-                    <Td className="custom-td">Cell with className</Td>
-                  </Tr>
-                  <Tr className="custom-tr">
-                    <Td>no</Td>
-                    <Td>yes</Td>
-                    <Td>no</Td>
-                    <Td>yes</Td>
-                    <Td>with className on Row</Td>
-                    <Td right className="custom-td">Right aligned with className</Td>
-                  </Tr>
-                </tbody>
-              </Table>
-            </TableContainer>
-            { /* s2:end */ }
-            <Snippet tag="s1" src={snippets} />
-            <Snippet tag="s2" src={snippets} />
+              <div className="docs">
+                <code>Td</code> and <code>Th</code> components accept a shortcut
+                prop for <code>nowrap</code>.
+              </div>
+              {/* s6:start */}
+              <TableContainer>
+                <TableTitle>Table Title</TableTitle>
+                <Table>
+                  <THead>
+                    <Tr>
+                      <Th>Header 1 - This column will push others to wrap</Th>
+                      <Th nowrap>Header 2 - This column will not wrap</Th>
+                      <Th>Header 3 wrap</Th>
+                    </Tr>
+                  </THead>
+                  <TBody>
+                    <Tr>
+                      <Td>
+                        long wrapping cell that pushes the other cells to the
+                        point of wrapping. long wrapping cell that pushes the
+                        other cells to the point of wrapping. long wrapping cell
+                        that pushes the other cells to the point of wrapping.
+                        long wrapping cell that pushes the other cells to the
+                        point of wrapping. long wrapping cell that pushes the
+                        other cells to the point of wrapping. long wrapping cell
+                        that pushes the other cells to the point of wrapping.
+                        long wrapping cell that pushes the other cells to the
+                        point of wrapping. long wrapping cell that pushes the
+                        other cells to the point of wrapping.
+                      </Td>
+                      <Td nowrap>no wrap</Td>
+                      <Td>wrap wrap wrap</Td>
+                    </Tr>
+                    <Tr>
+                      <Td>1</Td>
+                      <Td nowrap>2</Td>
+                      <Td>3</Td>
+                    </Tr>
+                  </TBody>
+                  <TFoot>
+                    <Tr>
+                      <Th>Footer Section 1</Th>
+                      <Th nowrap>Footer Section 2</Th>
+                      <Th>Footer Section 3</Th>
+                    </Tr>
+                  </TFoot>
+                </Table>
+              </TableContainer>
+              {/* s6:end */}
+              <Snippet tag="s6" src={snippets} />
+            </Body>
+          </Panel>
+
+          <Panel>
+            <Header>Cell Alignment</Header>
+            <Body>
+              <div className="docs">
+                <code>Th</code> and <code>Td</code> components accept this
+                shorthand props <code>center</code> and <code>right</code> for
+                text alignment. Left is the default.
+              </div>
+              {/* s4:start */}
+              <TableContainer>
+                <TableTitle>Table Title</TableTitle>
+                <Table>
+                  <THead>
+                    <Tr>
+                      <Th>Header Left</Th>
+                      <Th center>Header Center</Th>
+                      <Th right>Header Right</Th>
+                    </Tr>
+                  </THead>
+                  <TBody>
+                    <Tr>
+                      <Td>1</Td>
+                      <Td center>2</Td>
+                      <Td right>3</Td>
+                    </Tr>
+                    <Tr>
+                      <Td>1</Td>
+                      <Td center>2</Td>
+                      <Td right>3</Td>
+                    </Tr>
+                  </TBody>
+                  <TFoot>
+                    <Tr>
+                      <Th>Footer Section Left</Th>
+                      <Th center>Footer Section Center</Th>
+                      <Th right>Footer Section Right</Th>
+                    </Tr>
+                  </TFoot>
+                </Table>
+              </TableContainer>
+              {/* s4:end */}
+              <Snippet tag="s4" src={snippets} />
+            </Body>
+          </Panel>
+
+          <Panel>
+            <Header>Complex Table Example</Header>
+            <Body>
+              <div className="docs">
+                This demonstrates all the features of the table components.
+              </div>
+              {/* s5:start */}
+              <TableContainer className="custom-table-container">
+                <TableTitle className="custom-table-title">
+                  Table Title w/ Custom Color
+                </TableTitle>
+                <Table className="custom-table">
+                  <THead className="custom-header">
+                    <Tr>
+                      <Th>Header 1</Th>
+                      <Th>Header 2</Th>
+                      <Th>Header 3 wrap wrap</Th>
+                      <Th center>Header 4 centered</Th>
+                      <Th nowrap>Header w/ nowrap nowrap nowrap</Th>
+                      <Th right className="custom-th">
+                        Header with className
+                      </Th>
+                    </Tr>
+                  </THead>
+                  <TBody>
+                    <Tr>
+                      <Td>1</Td>
+                      <Td>2</Td>
+                      <Td>wrap wrap</Td>
+                      <Td center>4</Td>
+                      <Td>5</Td>
+                      <Td right>6</Td>
+                    </Tr>
+
+                    <Tr>
+                      <Td>1</Td>
+                      <Td>2</Td>
+                      <Td>wrap wrap</Td>
+                      <Td center>4</Td>
+                      <Td nowrap>this will not wrap this will not wrap</Td>
+                      <Td right className="custom-td">
+                        Cell with className
+                      </Td>
+                    </Tr>
+                    <Tr className="custom-tr">
+                      <Td>1</Td>
+                      <Td>2</Td>
+                      <Td>wrap wrap</Td>
+                      <Td center>4</Td>
+                      <Td>with className on Row</Td>
+                      <Td right>6</Td>
+                    </Tr>
+                    <Tr>
+                      <Td>1</Td>
+                      <Td>
+                        long wrapping cell that pushes the other cells to the
+                        point of wrapping. long wrapping cell that pushes the
+                        other cells to the point of wrapping. long wrapping cell
+                        that pushes the other cells to the point of wrapping.
+                        long wrapping cell that pushes the other cells to the
+                        point of wrapping. long wrapping cell that pushes the
+                        other cells to the point of wrapping. long wrapping cell
+                        that pushes the other cells to the point of wrapping.
+                        long wrapping cell that pushes the other cells to the
+                        point of wrapping. long wrapping cell that pushes the
+                        other cells to the point of wrapping.
+                      </Td>
+                      <Td>wrap wrap</Td>
+                      <Td className="custom-td-colspan" colSpan={2}>
+                        colspan 2 with className
+                      </Td>
+                      <Td right>6</Td>
+                    </Tr>
+                  </TBody>
+                  <TFoot className="custom-footer">
+                    <Tr>
+                      <Th>Footer Section 1</Th>
+                      <Th>Footer Section 2</Th>
+                      <Th>Footer Section 3</Th>
+                      <Th center>Footer Section 4 centered</Th>
+                      <Th>Footer Section 5</Th>
+                      <Th right>Footer Section 6</Th>
+                    </Tr>
+                  </TFoot>
+                </Table>
+              </TableContainer>
+              {/* s5:end */}
+              <Snippet tag="s5" src={snippets} />
             </Body>
           </Panel>
         </div>
       );
     }}
-  </Demo>;
+  </Demo>
+);

--- a/packages/visual-stack-docs/src/containers/Components/index.css
+++ b/packages/visual-stack-docs/src/containers/Components/index.css
@@ -1,0 +1,15 @@
+.docs {
+  padding: .5em;
+}
+
+.docs ul {
+  padding-left: 20px;
+}
+
+.docs li:first-child {
+  /* background-color: red; */
+  padding-top: 8px;
+}
+.docs li {
+  padding: 5px;
+}

--- a/packages/visual-stack-docs/src/containers/Components/index.js
+++ b/packages/visual-stack-docs/src/containers/Components/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import './index.css';
 
 const Components = ({ children }) =>
   <div>

--- a/packages/visual-stack/src/components/Table/Table.css
+++ b/packages/visual-stack/src/components/Table/Table.css
@@ -1,32 +1,31 @@
-.table-style {
+.vs-table {
     border-collapse: collapse;
     text-align: left;
     width: 100%;
 }
 
-.table-style > tbody > tr:hover {
+.vs-table > tbody > tr:hover {
     background-color: #f6f6f6;
  }
 
-.cell {
-    border: 1px;
+.vs-cell {
     border-top: 1px solid #eee;
     vertical-align: top;
     padding: 4px 5px;
     margin: 0;
 }
 
-.right-align {
+.vs-cell-right {
     text-align: right;
 }
 
-.panel {
+.vs-table-container {
     border: 1px solid #ddd;
     padding: 5px 10px;
     margin-bottom: 10px;
 }
 
-.panelTitle {
+.vs-table-title {
     line-height: 1em;
     font-variant: all-small-caps;
     font-weight: 600;
@@ -38,13 +37,13 @@
 }
 
 @media (max-width: 600px) {
-    .cell {
+    .vs-cell {
         max-width: 60px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
     }
-    .cell:first-child {
+    .vs-cell:first-child {
       max-width: 100px;
     }
 }

--- a/packages/visual-stack/src/components/Table/Table.css
+++ b/packages/visual-stack/src/components/Table/Table.css
@@ -1,49 +1,74 @@
-.vs-table {
-    border-collapse: collapse;
-    text-align: left;
-    width: 100%;
-}
-
-.vs-table > tbody > tr:hover {
-    background-color: #f6f6f6;
- }
-
-.vs-cell {
-    border-top: 1px solid #eee;
-    vertical-align: top;
-    padding: 4px 5px;
-    margin: 0;
-}
-
-.vs-cell-right {
-    text-align: right;
-}
-
 .vs-table-container {
-    border: 1px solid #ddd;
-    padding: 5px 10px;
-    margin-bottom: 10px;
+  border: 1px solid #ddd;
+  padding: 5px 10px;
+  margin: 10px 0;
 }
 
 .vs-table-title {
-    line-height: 1em;
-    font-variant: all-small-caps;
-    font-weight: 600;
-    font-size: 1.5em;
-    color: #333;
-    padding-bottom: 3px;
-    border-bottom: 0px solid #f0f0f0;
-    margin-bottom: 3px;
+  line-height: 1em;
+  font-variant: all-small-caps;
+  font-weight: 600;
+  font-size: 1.5em;
+  color: #333;
+  padding-bottom: 3px;
+  border-bottom: 0px solid #f0f0f0;
+  margin-bottom: 3px;
+}
+
+.vs-table {
+  border-collapse: collapse;
+  text-align: left;
+  width: 100%;
+}
+
+.vs-table > tbody > tr:hover {
+  background-color: #f6f6f6;
+ }
+
+.vs-tbody {
+}
+
+.vs-tfoot {
+}
+
+.vs-row {
+}
+
+.vs-thead .vs-cell {
+  border-bottom: 1px solid #ccc;
+}
+
+.vs-tfoot .vs-cell {
+  border-top: 1px solid #ccc;
+}
+
+
+.vs-cell {
+  border-top: 1px solid #eee;
+  vertical-align: top;
+  padding: 4px 5px;
+  margin: 0;
+}
+
+.vs-cell-right {
+  text-align: right;
+}
+
+.vs-cell-center {
+  text-align: center;
+}
+.vs-cell-nowrap {
+  white-space: nowrap;
 }
 
 @media (max-width: 600px) {
-    .vs-cell {
-        max-width: 60px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-    .vs-cell:first-child {
-      max-width: 100px;
-    }
+  .vs-cell {
+    max-width: 50px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .vs-cell:first-child {
+    max-width: 100px;
+  }
 }

--- a/packages/visual-stack/src/components/Table/Table.js
+++ b/packages/visual-stack/src/components/Table/Table.js
@@ -2,28 +2,42 @@ import React from 'react';
 import cn from 'classnames';
 import './Table.css';
 
-export const Table = ({ className, children }) =>
-  <table className={cn('vs-table', className)}>{children}</table>;
+export const TableContainer = ({ className, children, ...rest }) =>
+  <div className={cn('vs-table-container', className)} {...rest}>{children}</div>;
 
-export const Th = ({ className, children }) =>
-  <th className={cn('vs-cell', 'vs-table-header', className)}>{children}</th>;
+export const TableTitle = ({ className, children, ...rest }) =>
+  <div className={cn('vs-table-title', className)} {...rest}>{children}</div>;
 
-export const Tr = ({ className, children }) =>
-  <tr className={cn(className)}>{children}</tr>;
+export const Table = ({ className, children, ...rest }) =>
+  <table className={cn('vs-table', className)} {...rest}>{children}</table>;
 
-export const TrHead = ({ children }) => <thead><Tr>{children}</Tr></thead>;
+export const TBody = ({ className, children, ...rest }) =>
+  <tbody className={cn('vs-tbody', className)} {...rest}>{children}</tbody>;
 
-export const Td = ({ right, className, children }) =>
-  <td className={
-    cn('vs-cell', className, { 'vs-cell-right': right })
-  }>{children}</td>;
+export const THead = ({ className, children, ...rest }) =>
+  <thead className={cn('vs-thead', className)} {...rest}>{children}</thead>;
 
-export const TdRight = ({ className, children }) =>
-  <Td className={cn('vs-cell-right', className)}>{children}</Td>;
+export const TFoot = ({ className, children, ...rest }) =>
+  <tfoot className={cn('vs-tfoot', className)} {...rest}>{children}</tfoot>;
 
-export const TableContainer = ({ className, children }) =>
-  <div className={cn('vs-table-container', className)}>{children}</div>;
+export const Tr = ({ className, children, ...rest }) =>
+  <tr className={cn('vs-row', className)} {...rest}>{children}</tr>;
 
-export const TableTitle = ({ className, children }) =>
-  <div className={cn('vs-table-title', className)}>{children}</div>;
+const buildCellClasses = (center, className, nowrap, right) => {
+  return cn(
+    'vs-cell',
+    className,
+    { 'vs-cell-right': right },
+    { 'vs-cell-center': center },
+    { 'vs-cell-nowrap': nowrap }
+  );
+};
+
+export const Th = ({ center, className, nowrap, right, children, ...rest }) =>
+  <th className={`${buildCellClasses(center, className, nowrap, right)} vs-table-header`} {...rest}>{children}</th>;
+
+export const Td = ({ center, className, nowrap, right, children, ...rest }) =>
+  <td className={buildCellClasses(center, className, nowrap, right)} {...rest}>
+    {children}
+  </td>;
 

--- a/packages/visual-stack/src/components/Table/Table.js
+++ b/packages/visual-stack/src/components/Table/Table.js
@@ -1,18 +1,29 @@
 import React from 'react';
+import cn from 'classnames';
 import './Table.css';
 
-export const Table = ({ children }) => <table className="table-style">{children}</table>;
+export const Table = ({ className, children }) =>
+  <table className={cn('vs-table', className)}>{children}</table>;
 
-export const Th = ({ children }) => <th className="cell table-header">{children}</th>;
+export const Th = ({ className, children }) =>
+  <th className={cn('vs-cell', 'vs-table-header', className)}>{children}</th>;
 
-export const Tr = ({ children }) => <tr className="cell">{children}</tr>;
+export const Tr = ({ className, children }) =>
+  <tr className={cn(className)}>{children}</tr>;
 
 export const TrHead = ({ children }) => <thead><Tr>{children}</Tr></thead>;
 
-export const Td = ({ children }) => <td className="cell">{children}</td>;
+export const Td = ({ right, className, children }) =>
+  <td className={
+    cn('vs-cell', className, { 'vs-cell-right': right })
+  }>{children}</td>;
 
-export const TdRight = ({ children }) => <td className="cell right-align">{children}</td>;
+export const TdRight = ({ className, children }) =>
+  <Td className={cn('vs-cell-right', className)}>{children}</Td>;
 
-export const TableContainer = ({ children }) => <div className="panel">{children}</div>;
+export const TableContainer = ({ className, children }) =>
+  <div className={cn('vs-table-container', className)}>{children}</div>;
 
-export const TableTitle = ({ children }) => <div className="panelTitle">{children}</div>;
+export const TableTitle = ({ className, children }) =>
+  <div className={cn('vs-table-title', className)}>{children}</div>;
+

--- a/packages/visual-stack/src/components/Table/index.js
+++ b/packages/visual-stack/src/components/Table/index.js
@@ -1,1 +1,12 @@
-export { Table, Th, Tr, Td, TableContainer, TableTitle, TdRight, TrHead } from './Table.js';
+export {
+  TableContainer,
+  TableTitle,
+  Table,
+  THead,
+  TBody,
+  TFoot,
+  Th,
+  Tr,
+  Td,
+} from './Table.js';
+


### PR DESCRIPTION
This PR makes the following changes to `Table` and related components:

- All components accept a `className` prop
- All components accept and forward unhandled props to the underlying React component
- Adds `right`, `center`, and `nowrap` shorthand props to `Td` and `Th`
- Removes the `TdRight` component in favor of `<Td right>`
- Renames all CSS classes with a `vs-` prefix
- Expands the documentation to explain the changes


