### PR TITLE
Fix Form Component

### DIFF
--- a/packages/visual-stack-docs/src/containers/Components/Docs/form.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/form.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Panel, Body, Header } from '@cjdev/visual-stack/lib/components/Panel';
 import { Demo, Snippet } from '../../../components/Demo';
-import { Form, FormGroup, Label, Input } from '@cjdev/visual-stack/lib/components/Form';
+{ /* s3:start */ }
+import { Form, FormGroup, Label, Input, Legend } from '@cjdev/visual-stack/lib/components/Form';
+{ /* s3:end */ }
 
 export default () =>
     <Demo srcFile="/samples/src/containers/Components/Docs/form.js">
@@ -21,6 +23,7 @@ export default () =>
                 </FormGroup>
               </Form>
               { /* s2:end */ }
+              <Snippet tag="s3" src={snippets} />
               <Snippet tag="s2" src={snippets} />
             </Body>
           </Panel>
@@ -35,6 +38,7 @@ export default () =>
                 <FormGroup vertical={false}>
                   <Label required={true}>Some Label</Label>
                   <Input/>
+                  <Legend>Something</Legend>
                 </FormGroup>
               </Form>
               { /* s1:end */ }

--- a/packages/visual-stack-docs/src/containers/Components/Docs/form.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/form.js
@@ -1,9 +1,10 @@
+/* eslint */
 import React from 'react';
 import { Panel, Body, Header } from '@cjdev/visual-stack/lib/components/Panel';
 import { Demo, Snippet } from '../../../components/Demo';
-{ /* s3:start */ }
+/* s3:start */
 import { Form, FormGroup, Label, Input, Legend } from '@cjdev/visual-stack/lib/components/Form';
-{ /* s3:end */ }
+/* s3:end */
 
 export default () =>
     <Demo srcFile="/samples/src/containers/Components/Docs/form.js">

--- a/packages/visual-stack-docs/src/containers/Components/Docs/form.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/form.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Panel, Body, Header } from '@cjdev/visual-stack/lib/components/Panel';
+import { Demo, Snippet } from '../../../components/Demo';
+import { Form, FormGroup, Label, Input } from '@cjdev/visual-stack/lib/components/Form';
+
+export default () =>
+    <Demo srcFile="/samples/src/containers/Components/Docs/form.js">
+    { snippets => {
+      return (
+        <div>
+          <Panel>
+            <Header>
+              Default Buttons
+            </Header>
+            <Body>
+              { /* s2:start */ }
+              <Form vertical={false}>
+                <FormGroup vertical={false}>
+                  <Label required={true}>Some Label</Label>
+                  <Input/>
+                </FormGroup>
+              </Form>
+              { /* s2:end */ }
+              <Snippet tag="s2" src={snippets} />
+            </Body>
+          </Panel>
+
+          <Panel>
+            <Header>
+              Large Buttons
+            </Header>
+            <Body>
+              { /* s1:start */ }
+              <Form vertical={false}>
+                <FormGroup vertical={false}>
+                  <Label required={true}>Some Label</Label>
+                  <Input/>
+                </FormGroup>
+              </Form>
+              { /* s1:end */ }
+              <Snippet tag="s1" src={snippets} />
+            </Body>
+          </Panel>
+        </div>
+      );
+    }}
+  </Demo>;
+

--- a/packages/visual-stack-docs/src/containers/Components/Docs/index.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/index.js
@@ -11,6 +11,7 @@ const addComponentRoute = (path, linkName, component) => {
 // 1. add an import for your demo
 import BlankSlateDocs from './blankslate';
 import ButtonDocs from './button';
+import FormDocs from './form';
 import ListDocs from './list';
 import ModalDocs from './modal';
 import PanelDocs from './panel';
@@ -24,6 +25,7 @@ import TabLayoutDocs from './tablayout';
 // 2. add your demo to the routeComponentMap
 addComponentRoute('blankslate', 'Blank Slate', <BlankSlateDocs />);
 addComponentRoute('button', 'Button', <ButtonDocs />);
+addComponentRoute('form', 'Form', <FormDocs />);
 addComponentRoute('list', 'List', <ListDocs />);
 addComponentRoute('modal', 'Modal', <ModalDocs />);
 addComponentRoute('panel', 'Panel', <PanelDocs />);

--- a/packages/visual-stack/src/components/Form.css
+++ b/packages/visual-stack/src/components/Form.css
@@ -1,96 +1,96 @@
-.vs-form-horizontal .vs-form-group-vertical {
+.form-horizontal .form-group-vertical {
     margin-right: 0;
     margin-left: 0;
 }
 
-.vs-form-group-buttons {
+.form-group-buttons {
     text-align: right;
 }
 
-.vs-form-group-buttons .vs-form-button {
+.form-group-buttons .form-button {
     margin-left: 10px;
 }
 
-.vs-form-label-vertical {
+.form-label-vertical {
     margin-bottom: .3em;
 }
 
-.vs-form-label-text-vertical {
+.form-label-text-vertical {
     font-size: 1.1em;
 }
 
-.vs-form-group-static-text {
+.form-group-static-text {
     line-height: 32px;
     padding: 1px 6px;
 }
 
-.vs-form-group-required-sign {
+.form-group-required-sign {
     padding-left: .3em;
     color: #E1523D;
 }
 
-.vs-form-group-error-span {
+.form-group-error-span {
     display: block;
     color: #E1523D;
     top: 6px;
     position: relative;
 }
 
-.vs-has-error .vs-control-label {
+.has-error .control-label {
     color: #E1523D;
 }
 
-.vs-has-error .vs-form-control {
+.has-error .form-control {
     border-color: #E1523D;
 }
 
-.vs-form-group-radio-label {
+.form-group-radio-label {
     font-size: 1em;
     cursor: pointer;
     cursor: hand;
 }
 
-.vs-cj-form-input.vs-form-group-radio-input {
+.cj-form-input.form-group-radio-input {
     min-height: 24px;
     margin-bottom: 0;
 }
 
-.vs-has-help-icon {
+.has-help-icon {
     display: inline;
     overflow: visible;
     float: left;
 }
 
-.vs-help-icon-form-component {
+.help-icon-form-component {
     margin-left: 15px;
 }
 
-.vs-clipboard-input {
+.clipboard-input {
     color: #9E868E;
     background-color: inherit;
     cursor: default;
 }
 
-.vs-clipboard-button {
+.clipboard-button {
     padding-top: 6px;
     padding-right: 12px;
 }
 
-.vs-clipboard-button:focus {
+.clipboard-button:focus {
     outline: 0;
 }
 
-.vs-row-destinationUrl .vs-tooltip-inner {
+.row-destinationUrl .tooltip-inner {
     width: 350px;
     max-width: 350px;
 }
 
-.vs-fieldset-title {
+.fieldset-title {
     border-bottom: 1px solid #e5e5e5;
     margin-bottom: 20px;
 }
 
-.vs-fieldset-panel {
+.fieldset-panel {
     border: 1px solid #e5e5e5;
     margin-bottom: 20px;
 }

--- a/packages/visual-stack/src/components/Form.js
+++ b/packages/visual-stack/src/components/Form.js
@@ -5,7 +5,7 @@ import './Form.css';
 export const Input = ({ className, type, ...otherProps }) =>
   <input
     type={type || 'text'}
-    className={`vs-form-control ${className || ''}`}
+    className={`form-control ${className || ''}`}
     {...otherProps} />;
 Input.propTypes = {
   className: PropTypes.string,
@@ -13,9 +13,9 @@ Input.propTypes = {
 };
 
 export const Label = ({ children, className, required, vertical, ...otherProps }) =>
-  <label className={`vs-form-label vs-control-label vs-form-label-${vertical ? 'vertical' : 'horizontal'} ${className || ''}`} {...otherProps}>
+  <label className={`form-label control-label form-label-${vertical ? 'vertical' : 'horizontal'} ${className || ''}`} {...otherProps}>
     {children}
-    {required && <span className="vs-form-group-required-sign">*</span>}
+    {required && <span className="form-group-required-sign">*</span>}
   </label>;
 Label.propTypes = {
   className: PropTypes.string,
@@ -26,17 +26,17 @@ export const Legend = ({ children, ...otherProps }) =>
   <legend {...otherProps}>{children}</legend>;
 
 export const Form = ({ children, vertical, ...otherProps }) =>
-  <form className={vertical ? 'vs-form-vertical' : 'vs-form-horizontal'} {...otherProps}>{children}</form>;
+  <form className={vertical ? 'form-vertical' : 'form-horizontal'} {...otherProps}>{children}</form>;
 
 export const FormGroup = ({ children, error, label, required, vertical }) =>
-  <div className={`vs-form-group ${error ? 'vs-has-error' : ''}`}>
+  <div className={`form-group ${error ? 'has-error' : ''}`}>
     {label ? <Label vertical={vertical} className={!vertical ? 'col-sm-3' : ''} required={required}>{label}</Label>
            : <div className={!vertical ? 'col-sm-3' : ''} />}
     <div className={!vertical ? 'col-sm-5' : ''}>
       {children}
     </div>
-    <div className={`vs-error-container ${!vertical ? 'col-xs-4' : ''}`}>
-      {error && <div className="vs-form-group-error-span">{error}</div>}
+    <div className={`error-container ${!vertical ? 'col-xs-4' : ''}`}>
+      {error && <div className="form-group-error-span">{error}</div>}
     </div>
   </div>;
 FormGroup.propTypes = {


### PR DESCRIPTION
Form components uses bootstrap css for styling, so name spacing it will break the component itself.
This PR also includes a VERY minimal document for the Form component, so this kind of error can be checked for (at least manually by visual testing) 
Addresses #107 and will hopefully be the last PR for #95 
