### PR TITLE
Update layout metrics (8px unit system)

### DIFF
--- a/packages/visual-stack/src/components/CJLogo.css
+++ b/packages/visual-stack/src/components/CJLogo.css
@@ -1,4 +1,4 @@
 .vs-cj-logo {
-  width: 30px;
-  margin-top: 2px;
+  width: 34px;
+  margin-top: 4px;
 }

--- a/packages/visual-stack/src/components/PageContent.css
+++ b/packages/visual-stack/src/components/PageContent.css
@@ -3,8 +3,8 @@
   flex-direction: column;
   background-color: #F1F4F8;
   margin: 0;
-  padding: 15px 1em;
+  padding: 24px;
   overflow: auto;
-  height: calc(100vh - 45px);
+  height: calc(100vh - 48px);
 }
 

--- a/packages/visual-stack/src/components/PageHeader.css
+++ b/packages/visual-stack/src/components/PageHeader.css
@@ -7,22 +7,22 @@
   justify-content: space-between;
   z-index: 90;
   align-items: center;
-  min-height: 45px;
+  min-height: 48px;
   padding: 0 16px;
   position: relative;
-  box-shadow: 0 1px 2px rgba(0,0,0,.16);
-/* 						  0 2px 3px rgba(0,0,0,.1); */
-/* 						  0 3px 4px -1px rgba(0,0,0,.1); */
+  box-shadow: 0 1px 2px rgba(0,0,0,.08),
+/*							0 2px 3px rgba(0,0,0,.1),  */
+						  0 3px 4px -1px rgba(0,0,0,.08);
 	z-index: 2;
 }
 
 @media (min-width: 40em) {
   .vs-page-heading--title {
-    width: calc(100% - 255px);
+    width: calc(100% - 256px);
   }
 
   .vs-application-layout-side-collapsed+.vs-application-layout-content .vs-page-heading--title {
-    width: calc(100% - 50px);
+    width: calc(100% - 48px);
   }
 }
 
@@ -42,9 +42,9 @@
 }
 
 .vs-page-heading--description {
-  padding-left: 15px;
   border-left: 1px solid rgb(195, 195, 195);
   font-size: 13px;
-  margin-left: 15px;
   font-weight: 400;
+  margin-left: 16px;
+  padding-left: 16px;
 }

--- a/packages/visual-stack/src/components/SideNav/SideNav.css
+++ b/packages/visual-stack/src/components/SideNav/SideNav.css
@@ -2,7 +2,7 @@
 .vs-sidenav {
   background-color: #2A3038;
   list-style: none;
-  width: 55px;
+  width: 48px;
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
@@ -13,11 +13,11 @@
   font-weight: 400;
   user-select:none;
   margin: 0;
-  padding: 0 0 100px 0;
+  padding: 0 0 96px 0;
 }
 
 .vs-sidenav ul {
-  padding-bottom: 100px;
+  padding-bottom: 96px;
 }
 
 .vs-sidenav h1,
@@ -28,12 +28,12 @@
 }
 
 .vs-sidenav.active {
-  width: 255px;
+  width: 256px;
 }
 
 @media (min-width: 40em) {
   .vs-sidenav.collapsed {
-    width: 55px;
+    width: 48px;
     transition: .4s width ease-out;
 /* 	  transition: .4s width cubic-bezier(0.22, 0.61, 0.36, 1); */
   }
@@ -49,7 +49,7 @@
 .vs-sideNav-left-logo {
 	background: #49c5b1;
   display: flex;
-  height: 45px;
+  height: 48px;
 }
 
 .vs-sideNav-left-logo a.vs-sidenav-container-row:hover,
@@ -71,12 +71,12 @@
 .vs-sidenav .vs-sideNav-left-logo .vs-sidenav-container-row  {
 }
 .vs-logo {
-  padding: 10px;
+  padding: 8px;
 }
 
 .vs-logo .vs-cj-logo {
-  width: 32px;
   fill: white;
+  width: 34px;
 }
 
 .vs-app-name {
@@ -178,7 +178,7 @@
   color: #bfc3c8;
   display: flex;
   height: 48px;
-  padding: 12px 18px;
+  padding: 15px;
   text-decoration: none;
   transition: .1s all ease-in-out;
 }
@@ -319,7 +319,7 @@
 }
 
 .vs-stacked-icon {
-  margin-right: 9px;
+  margin-right: 8px;
 }
 
 .vs-sidenav-link-content-wrapper {
@@ -351,7 +351,7 @@
   height: 24px;
   width: 24px;
   margin-right: 16px;
-  margin-left: -4px;
+  margin-left: -3px;
   display:flex;
   flex-wrap: nowrap;
   justify-content: center;
@@ -364,5 +364,5 @@
 .vs-user-icon-last {
   font-size: 12px;
   font-weight: 300;
-  margin: 0 .5px;
+  margin: 0 .4px;
 }

--- a/packages/visual-stack/src/layouts/ApplicationLayout/style.css
+++ b/packages/visual-stack/src/layouts/ApplicationLayout/style.css
@@ -27,7 +27,7 @@ body {
 .vs-application-layout-side {
   flex: 0 0 auto;
   overflow: auto;
-  margin-left: 50px;
+  margin-left: 48px;
   transition: all .4s ease-out;
 }
 
@@ -40,13 +40,13 @@ body {
 
 @media (min-width: 40em) {
   .vs-application-layout-side {
-    flex: 0 0 255px;
+    flex: 0 0 256px;
     margin-left: 0px;
     transition: all .4s ease-out;
   }
 
   .vs-application-layout-side-collapsed {
-    flex: 0 0 55px;
+    flex: 0 0 48px;
     margin-left: 0px;
     transition: all .4s ease-out;
   }


### PR DESCRIPTION
Apply 8px unit system of measurement for optimized rendering for devices/displays. 
- Deepen box-shadow for page-header
- Adjust sidenav logo/icon sizing for 8px 
- Increase pageContent padding to 24px 
- sideNav width increased to 256px
- collapsed sideNav width decreased to 48px
- topbar min-height increased to 48px