### PR TITLE
CJPM-10596: move logout link to end of user menu

### DIFF
--- a/packages/visual-stack-redux/src/components/SideNav/SideNav.js
+++ b/packages/visual-stack-redux/src/components/SideNav/SideNav.js
@@ -12,8 +12,8 @@ export const UserMenu = ({ onLogout, label, firstInitial, lastInitial, color, ch
     label={label}
     icon={<UserIcon firstInitial={firstInitial} lastInitial={lastInitial} color={color} />}
   >
-    <LogoutLink onLogout={onLogout} label={logoutLabel}/>
     {children}
+    <LogoutLink onLogout={onLogout} label={logoutLabel}/>
   </LinkGroup>
 );
 


### PR DESCRIPTION
To match the member user menu, we need to add a privacy policy link and a copyright statement to the top of the UserMenu, before the LogoutLink.