### PR TITLE
SideNav accepts optional callback for logo click

### DIFF
--- a/packages/visual-stack-docs/src/containers/App/SideNav.js
+++ b/packages/visual-stack-docs/src/containers/App/SideNav.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import * as R from 'ramda';
 
-import { Link as RRLink } from 'react-router';
 import LayoutIcon from 'mdi-react/TelevisionGuideIcon';
 import GettingStartedIcon from 'mdi-react/FileDocumentIcon';
 import ComponentIcon from 'mdi-react/HexagonMultipleIcon';
@@ -20,6 +19,7 @@ import {
   UserMenuLink,
 } from '@cjdev/visual-stack-redux/lib/components/SideNav';
 import CJLogo from '@cjdev/visual-stack/lib/components/CJLogo';
+import { Link as RRLink, withRouter } from 'react-router';
 /* s3:end */
 import { routeComponentMap } from '../Components/Docs/';
 import { layoutsRouteMap } from '../Layouts';
@@ -36,9 +36,10 @@ const componentLinks = toLinks(routeComponentMap);
 const layoutLinks = toLinks(layoutsRouteMap);
 
 
-export default class AppSideNav extends React.Component {
+class AppSideNav extends React.Component {
   render() {
   /* s1:start */
+    const { router } = this.props;
     const userMenu =
       <UserMenu
         onLogout={() => { alert('handleLogout'); }}
@@ -59,7 +60,10 @@ export default class AppSideNav extends React.Component {
       <SideNav
         userMenu={userMenu}
         initializedCollapsed={false}
-        homeLink={'this/defaults/to/"/"'}
+        onLogoClick={() => router.push('/')}
+          /* onLogoClick is useful for client side routers */
+          /* or homeLink="/components/sidenav"*/
+          /* defaults to homeLink="/" */
         logoBackground="#00AF66"
         logo={<CJLogo />}
         appName="VISUAL STACK"
@@ -99,3 +103,4 @@ export default class AppSideNav extends React.Component {
     );
   }
 }
+export default withRouter(AppSideNav);

--- a/packages/visual-stack/package-lock.json
+++ b/packages/visual-stack/package-lock.json
@@ -5006,7 +5006,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -5018,7 +5019,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5149,7 +5151,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5163,6 +5166,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -5302,7 +5306,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",

--- a/packages/visual-stack/src/components/SideNav/SideNav.js
+++ b/packages/visual-stack/src/components/SideNav/SideNav.js
@@ -69,7 +69,11 @@ class SideNavP extends React.Component {
       <ul className={'vs-sidenav' + (collapsed ? ' collapsed' : ' active')}>
         <li className="vs-sideNav-left-logo">
           {onLogoClick ? (
-            <span onClick={onLogoClick} className="vs-sidenav-container-row">
+            <span 
+              role="link" 
+              tabIndex="0"
+              onKeyDown={onLogoClick}
+              onClick={onLogoClick} className="vs-sidenav-container-row">
               <div className="vs-logo">{this.props.logo}</div>
               <span className="vs-app-name">{capAppName}</span>
             </span>

--- a/packages/visual-stack/src/components/SideNav/SideNav.js
+++ b/packages/visual-stack/src/components/SideNav/SideNav.js
@@ -74,7 +74,7 @@ class SideNavP extends React.Component {
               tabIndex="0"
               onKeyDown={onLogoClick}
               onClick={onLogoClick} className="vs-sidenav-container-row">
-              <div className="vs-logo">{this.props.logo}</div>
+              <span className="vs-logo">{this.props.logo}</span>
               <span className="vs-app-name">{capAppName}</span>
             </span>
           ) : (

--- a/packages/visual-stack/src/components/SideNav/SideNav.js
+++ b/packages/visual-stack/src/components/SideNav/SideNav.js
@@ -55,20 +55,33 @@ class SideNavP extends React.Component {
       collapsed,
       children,
       userMenu,
-      homeLink
+      homeLink,
+      onLogoClick,
     } = this.props;
 
     const logoBg = logoBackground ? logoBackground : 'transparent';
     const toggle = () => onClick(!collapsed);
     const capAppName = appName ? appName.toUpperCase() : '';
-    const userMenuWithColor = (userMenu) ?  React.cloneElement(userMenu, { color: "#49c5b1" }) : null;
+    const userMenuWithColor = userMenu
+      ? React.cloneElement(userMenu, { color: '#49c5b1' })
+      : null;
     return (
       <ul className={'vs-sidenav' + (collapsed ? ' collapsed' : ' active')}>
         <li className="vs-sideNav-left-logo">
-          <a href={`${(homeLink) ? homeLink : '\/'}`} className="vs-sidenav-container-row">
-            <div className="vs-logo">{this.props.logo}</div>
-            <span className="vs-app-name">{capAppName}</span>
-          </a>
+          {onLogoClick ? (
+            <span onClick={onLogoClick} className="vs-sidenav-container-row">
+              <div className="vs-logo">{this.props.logo}</div>
+              <span className="vs-app-name">{capAppName}</span>
+            </span>
+          ) : (
+            <a
+              href={`${homeLink ? homeLink : '/'}`}
+              className="vs-sidenav-container-row"
+            >
+              <div className="vs-logo">{this.props.logo}</div>
+              <span className="vs-app-name">{capAppName}</span>
+            </a>
+          )}
         </li>
         {children}
         {userMenuWithColor}
@@ -82,4 +95,6 @@ class SideNavP extends React.Component {
 
 SideNav.propTypes = {
   active: PropTypes.bool,
+  homeLink: PropTypes.string,
+  onLogoClick: PropTypes.func,
 };


### PR DESCRIPTION
To support client-side routers, this adds a callback prop to the SideNav component, `onLogoClick`. This prop allows client code to interact with a router instead of having the component use a simple `a` tag for the logo.  