### PR TITLE
Fix TextArea styles and lint errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1297,7 +1297,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -2122,7 +2122,7 @@
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -3156,7 +3156,7 @@
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "http-cache-semantics": {
@@ -4124,7 +4124,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -4206,7 +4206,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4877,7 +4877,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -5658,7 +5658,7 @@
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -5789,7 +5789,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -5931,7 +5931,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -6321,7 +6321,7 @@
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"

--- a/packages/visual-stack-docs/src/containers/Components/Docs/form.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/form.js
@@ -1,4 +1,5 @@
 /* eslint */
+/* eslint-disable no-console */
 import React from 'react';
 import { Body, Header, Panel } from '@cjdev/visual-stack/lib/components/Panel';
 import { Demo, Snippet } from '../../../components/Demo';
@@ -309,9 +310,7 @@ export default () => (
               {/* s13:start */}
               <Form>
                 <FieldContent>
-                  <TextArea
-                    placeholder="Enter some text here..."
-                  />
+                  <TextArea placeholder="Enter some text here..." />
                 </FieldContent>
               </Form>
               {/* s13:end */}

--- a/packages/visual-stack-docs/src/containers/Components/Docs/form.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/form.js
@@ -311,7 +311,6 @@ export default () => (
                 <FieldContent>
                   <TextArea
                     placeholder="Enter some text here..."
-                    style={{ height: '64px' }}
                   />
                 </FieldContent>
               </Form>

--- a/packages/visual-stack-docs/src/containers/Components/Docs/select.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/select.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from 'react';
 import { Demo, Snippet } from '../../../components/Demo';
 import { Body, Header, Panel } from '@cjdev/visual-stack/lib/components/Panel';

--- a/packages/visual-stack-docs/src/containers/Layouts/DialogLayout/index.js
+++ b/packages/visual-stack-docs/src/containers/Layouts/DialogLayout/index.js
@@ -1,14 +1,29 @@
 import React from 'react';
-import {Route, withRouter} from 'react-router';
+import { Route, withRouter } from 'react-router';
 
-import {Button} from '@cjdev/visual-stack/lib/components/Button';
+import { Button } from '@cjdev/visual-stack/lib/components/Button';
 import DialogLayout from '@cjdev/visual-stack/lib/layouts/DialogLayout';
-import {Body, Footer, Header, Panel,} from '@cjdev/visual-stack/lib/components/Panel';
-import {ChoiceInput, Field, Form, Input, Label, TextField,} from '@cjdev/visual-stack/lib/components/Form';
-import {Demo, Snippet} from '../../../components/Demo';
+import {
+  Body,
+  Footer,
+  Header,
+  Panel,
+} from '@cjdev/visual-stack/lib/components/Panel';
+import {
+  ChoiceInput,
+  Field,
+  Form,
+  Input,
+  Label,
+  TextField,
+} from '@cjdev/visual-stack/lib/components/Form';
+import { Demo, Snippet } from '../../../components/Demo';
 import CJLogo from '@cjdev/visual-stack/lib/components/CJLogo';
 import './index.css';
-import {PageHeader, PageTitle,} from '@cjdev/visual-stack/lib/components/PageHeader';
+import {
+  PageHeader,
+  PageTitle,
+} from '@cjdev/visual-stack/lib/components/PageHeader';
 import PageContent from '@cjdev/visual-stack/lib/components/PageContent';
 
 class DialogLayoutParent extends React.Component {
@@ -62,19 +77,20 @@ class DialogLayoutParent extends React.Component {
                 <Panel>
                   <Header>DialogLayout with no footer buttons</Header>
                   <Body>
-                  <Button
-                    type="solid-primary"
-                    onClick={() =>
-                      this.props.router.push('/noFooterDialogLayout')
-                    }
-                  >
-                    Show the DialogLayout with no footer
-                  </Button>
-                  <p>
-                    On readonly views, you might not want buttons at the bottom.
-                    If you don't pass text for these buttons, they won't render.
-                  </p>
-                  <Snippet tag="s5" src={snippets} />
+                    <Button
+                      type="solid-primary"
+                      onClick={() =>
+                        this.props.router.push('/noFooterDialogLayout')
+                      }
+                    >
+                      Show the DialogLayout with no footer
+                    </Button>
+                    <p>
+                      On readonly views, you might not want buttons at the
+                      bottom. If you don't pass text for these buttons, they
+                      won't render.
+                    </p>
+                    <Snippet tag="s5" src={snippets} />
                   </Body>
                 </Panel>
                 <Panel>
@@ -152,9 +168,7 @@ export const NoFooterDialogLayoutDemo = ({ router }) => (
     >
       <Panel>
         <Header>Panel Header</Header>
-        <Body>
-        This is the Panel Body.
-        </Body>
+        <Body>This is the Panel Body.</Body>
       </Panel>
     </DialogLayout>
   </div>

--- a/packages/visual-stack-docs/src/index.js
+++ b/packages/visual-stack-docs/src/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {browserHistory, IndexRoute, Route, Router} from 'react-router';
-import {combineReducers, createStore} from 'redux';
-import {Provider} from 'react-redux';
+import { browserHistory, IndexRoute, Route, Router } from 'react-router';
+import { combineReducers, createStore } from 'redux';
+import { Provider } from 'react-redux';
 
-import {reducer as vsReducer} from '@cjdev/visual-stack-redux';
+import { reducer as vsReducer } from '@cjdev/visual-stack-redux';
 import '@cjdev/visual-stack/lib/global';
 
 import App from './containers/App/';
@@ -12,7 +12,7 @@ import Home from './containers/Home/';
 import Components from './containers/Components/';
 import ComponentDocs from './containers/Components/Docs/';
 import Icons from './containers/Icons/';
-import Layouts, {LayoutsDocs} from './containers/Layouts';
+import Layouts, { LayoutsDocs } from './containers/Layouts';
 import GettingStarted from './containers/GettingStarted/';
 import './index.css';
 import {

--- a/packages/visual-stack/src/components/CreatableSelect/CreatableSelect.css
+++ b/packages/visual-stack/src/components/CreatableSelect/CreatableSelect.css
@@ -70,7 +70,7 @@ div.vs-react-select-creatable__multi-value {
   border-radius: 2px;
   border: 1px solid #29c3aa;
   color: #068e78;
-  font-size: .9em;
+  font-size: 0.9em;
   line-height: 1.4;
   vertical-align: top;
   white-space: wrap;

--- a/packages/visual-stack/src/components/Select/Select.css
+++ b/packages/visual-stack/src/components/Select/Select.css
@@ -76,7 +76,7 @@ div.vs-react-select__multi-value {
   border-radius: 2px;
   border: 1px solid #29c3aa;
   color: #068e78;
-  font-size: .9em;
+  font-size: 0.9em;
   line-height: 1.4;
   vertical-align: top;
   white-space: wrap;

--- a/packages/visual-stack/src/components/Select/tests/Select.test.js
+++ b/packages/visual-stack/src/components/Select/tests/Select.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Select from '../index';
-import Enzyme, { mount, shallow } from 'enzyme';
+import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/packages/visual-stack/src/components/SideNav/SideNav.js
+++ b/packages/visual-stack/src/components/SideNav/SideNav.js
@@ -49,7 +49,6 @@ class SideNavP extends React.Component {
 
   render() {
     const {
-      logoBackground,
       appName,
       onClick,
       collapsed,
@@ -58,7 +57,6 @@ class SideNavP extends React.Component {
       homeLink,
     } = this.props;
 
-    const logoBg = logoBackground ? logoBackground : 'transparent';
     const toggle = () => onClick(!collapsed);
     const capAppName = appName ? appName.toUpperCase() : '';
     const userMenuWithColor = userMenu

--- a/packages/visual-stack/src/components/SideNav/UserMenu.js
+++ b/packages/visual-stack/src/components/SideNav/UserMenu.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { Link, LinkContentWrapper } from './Link';
 import { LogoutIcon } from './Icons';
 
-export const UserIcon = ({ firstInitial, lastInitial, color }) => (
+export const UserIcon = ({ firstInitial, lastInitial }) => (
   <div className="vs-user-icon-circle">
     <span className="vs-user-icon-first">{firstInitial}</span>
     <span className="vs-user-icon-last">{lastInitial}</span>

--- a/packages/visual-stack/src/components/TabLayout/tests/index.test.js
+++ b/packages/visual-stack/src/components/TabLayout/tests/index.test.js
@@ -11,8 +11,6 @@ describe('TabLayout', () => {
   const el = document.createElement('div');
   document.body.appendChild(el);
 
-  const options = { attachTo: el };
-
   describe('functionaltesty', () => {
     test('should render', () => {
       const wrapper = mount(<TabLayout />);

--- a/packages/visual-stack/src/css/forms.css
+++ b/packages/visual-stack/src/css/forms.css
@@ -180,6 +180,7 @@ select[size] {
 
 textarea {
   overflow: auto;
+  height: 64px;
 }
 
 input[disabled],

--- a/packages/visual-stack/src/css/forms.css
+++ b/packages/visual-stack/src/css/forms.css
@@ -180,7 +180,7 @@ select[size] {
 
 textarea {
   overflow: auto;
-  height: 64px;
+  min-height: 64px;
 }
 
 input[disabled],

--- a/packages/visual-stack/src/css/forms.css
+++ b/packages/visual-stack/src/css/forms.css
@@ -203,27 +203,27 @@ fieldset[disabled] input[type='checkbox'] {
   cursor: not-allowed;
 }
 
-input::-webkit-input-placeholder {
+::-webkit-input-placeholder {
   color: #999;
   opacity: 1;
 }
 
-input::-moz-placeholder {
+::-moz-placeholder {
   color: #999;
   opacity: 1;
 }
 
-input:-ms-input-placeholder {
+:-ms-input-placeholder {
   color: #999;
   opacity: 1;
 }
 
-input::-ms-input-placeholder {
+::-ms-input-placeholder {
   color: #999;
   opacity: 1;
 }
 
-input::placeholder {
+::placeholder {
   color: #999;
   opacity: 1;
 }

--- a/packages/visual-stack/src/layouts/DialogLayout/index.js
+++ b/packages/visual-stack/src/layouts/DialogLayout/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Button} from '../../components/Button';
+import { Button } from '../../components/Button';
 import CloseIcon from 'mdi-react/CloseIcon';
 
 import './index.css';
@@ -17,17 +17,17 @@ function getSubmitButtonText(submitButtonText, showSubmitButtonSpinner) {
 }
 
 export const DialogLayout = ({
-                               className,
-                               title,
-                               cancelButtonText,
-                               submitButtonText,
-                               disableSubmit,
-                               showSubmitButtonSpinner,
-                               logo,
-                               onCancel,
-                               onSubmit,
-                               children,
-                             }) => (
+  className,
+  title,
+  cancelButtonText,
+  submitButtonText,
+  disableSubmit,
+  showSubmitButtonSpinner,
+  logo,
+  onCancel,
+  onSubmit,
+  children,
+}) => (
   <div className={`vs-dialog-layout ${className ? className : ''}`}>
     <div className="vs-dialog-layout-header">
       <div className="vs-dialog-layout-page-title">
@@ -35,27 +35,27 @@ export const DialogLayout = ({
           <span className="vs-cj-logo">{logo}</span>
         </div>
         <h1 className="vs-dialog-layout-title">{title}</h1>
-        <CloseIcon className="vs-dialog-layout-icon-close" onClick={onCancel}/>
+        <CloseIcon className="vs-dialog-layout-icon-close" onClick={onCancel} />
       </div>
     </div>
     <div className="vs-dialog-layout-content">{children}</div>
     <div className="vs-dialog-layout-footer">
+      {cancelButtonText && (
+        <Button id="vs-dialog-layout-cancel" type="text" onClick={onCancel}>
+          {cancelButtonText}
+        </Button>
+      )}
 
-      {cancelButtonText &&
-      <Button id="vs-dialog-layout-cancel" type="text" onClick={onCancel}>
-        {cancelButtonText}
-      </Button>}
-
-      {submitButtonText &&
-      <Button
-        id="vs-dialog-layout-submit"
-        type="solid-primary"
-        disabled={disableSubmit === true}
-        onClick={onSubmit}>
-
-        {getSubmitButtonText(submitButtonText, showSubmitButtonSpinner)}
-      </Button>}
-
+      {submitButtonText && (
+        <Button
+          id="vs-dialog-layout-submit"
+          type="solid-primary"
+          disabled={disableSubmit === true}
+          onClick={onSubmit}
+        >
+          {getSubmitButtonText(submitButtonText, showSubmitButtonSpinner)}
+        </Button>
+      )}
     </div>
   </div>
 );

--- a/packages/visual-stack/src/layouts/DialogLayout/tests/index.test.js
+++ b/packages/visual-stack/src/layouts/DialogLayout/tests/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Enzyme, {mount, shallow} from 'enzyme';
+import Enzyme, { mount, shallow } from 'enzyme';
 import DialogLayout from '../';
 import Adapter from 'enzyme-adapter-react-16';
 
@@ -7,18 +7,12 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe('DialogLayout', () => {
   test('should render', () => {
-    let onClickCalled = false;
-    const onClickFake = () => {
-      onClickCalled = true;
-    };
-
     const component = mount(
       <DialogLayout
         title="titleFromTest"
         cancelButtonText="testCancelButtonText"
         submitButtonText="testSubmitButtonText"
         logo={<div id="test-logo">I am a logo</div>}
-        onCancel={onClickFake}
       >
         <div id="test-children">I am a child</div>
       </DialogLayout>
@@ -49,9 +43,8 @@ describe('DialogLayout', () => {
 
   test('should render submit as disabled button when disableSubmit is true', () => {
     const component = shallow(
-      <DialogLayout
-        disableSubmit={true}
-        submitButtonText="Submit"/>);
+      <DialogLayout disableSubmit={true} submitButtonText="Submit" />
+    );
 
     const submitButton = component.find('#vs-dialog-layout-submit');
 
@@ -59,7 +52,7 @@ describe('DialogLayout', () => {
   });
 
   test('should not render submit button when not configured', () => {
-    const component = shallow(<DialogLayout/>);
+    const component = shallow(<DialogLayout />);
 
     const submitButton = component.find('#vs-dialog-layout-submit');
 
@@ -67,7 +60,7 @@ describe('DialogLayout', () => {
   });
 
   test('should not render cancel button when not configured', () => {
-    const component = shallow(<DialogLayout/>);
+    const component = shallow(<DialogLayout />);
 
     const cancelButton = component.find('#vs-dialog-layout-cancel');
 
@@ -81,9 +74,8 @@ describe('DialogLayout', () => {
     };
 
     const component = shallow(
-      <DialogLayout
-        onCancel={onClickFake}
-        cancelButtonText="Cancel"/>);
+      <DialogLayout onCancel={onClickFake} cancelButtonText="Cancel" />
+    );
 
     const cancelButton = component.find('#vs-dialog-layout-cancel');
 
@@ -99,9 +91,8 @@ describe('DialogLayout', () => {
     };
 
     const component = shallow(
-      <DialogLayout
-        onCancel={onClickFake}
-        cancelButtonText="Cancel"/>);
+      <DialogLayout onCancel={onClickFake} cancelButtonText="Cancel" />
+    );
 
     const closeIcon = component.find('.vs-dialog-layout-icon-close');
 
@@ -117,9 +108,8 @@ describe('DialogLayout', () => {
     };
 
     const component = shallow(
-      <DialogLayout
-        onSubmit={onClickFake}
-        submitButtonText="Submit"/>);
+      <DialogLayout onSubmit={onClickFake} submitButtonText="Submit" />
+    );
 
     const submitButton = component.find('#vs-dialog-layout-submit');
 


### PR DESCRIPTION
This fixes placeholder font styles for textareas by applying the styles to textareas too and not just inputs. The difference was made more noticeable when rendering inputs and textareas next to each other.

It also adds a sensible height default to textareas for consistency sake, avoiding having to manually specify the height on each use.

Also applies prettier project wide and fixes all other eslint errors and warnings. Could be an opportunity to start enforcing eslint at build time.