### PR TITLE
Remove collapsible padding and make header bold

### DIFF
--- a/packages/visual-stack/src/components/CollapsiblePanel.css
+++ b/packages/visual-stack/src/components/CollapsiblePanel.css
@@ -1,7 +1,3 @@
-.vs-collapsible-panel {
-  padding: 8px;
-}
-
 .vs-collapsible-panel-header {
   display: flex;
   align-items: center;
@@ -17,6 +13,7 @@
 
 .vs-collapsible-panel-header-title {
   user-select: none;
+  font-weight: 500;
 }
 
 .vs-collapsible-panel + .vs-collapsible-panel {


### PR DESCRIPTION
Padding was causing caret to have larger left margin vs. right margin.
Header being bold aligns with UX mockups.