### PR TITLE
Remove footer from DialogLayout and move buttons to the top; changed …

### DIFF
--- a/packages/visual-stack-docs/src/containers/Layouts/DialogLayout/index.js
+++ b/packages/visual-stack-docs/src/containers/Layouts/DialogLayout/index.js
@@ -1,29 +1,14 @@
 import React from 'react';
-import { Route, withRouter } from 'react-router';
+import {Route, withRouter} from 'react-router';
 
-import { Button } from '@cjdev/visual-stack/lib/components/Button';
+import {Button} from '@cjdev/visual-stack/lib/components/Button';
 import DialogLayout from '@cjdev/visual-stack/lib/layouts/DialogLayout';
-import {
-  Body,
-  Footer,
-  Header,
-  Panel,
-} from '@cjdev/visual-stack/lib/components/Panel';
-import {
-  ChoiceInput,
-  Field,
-  Form,
-  Input,
-  Label,
-  TextField,
-} from '@cjdev/visual-stack/lib/components/Form';
-import { Demo, Snippet } from '../../../components/Demo';
+import {Body, Footer, Header, Panel,} from '@cjdev/visual-stack/lib/components/Panel';
+import {ChoiceInput, Field, Form, Input, Label, TextField,} from '@cjdev/visual-stack/lib/components/Form';
+import {Demo, Snippet} from '../../../components/Demo';
 import CJLogo from '@cjdev/visual-stack/lib/components/CJLogo';
 import './index.css';
-import {
-  PageHeader,
-  PageTitle,
-} from '@cjdev/visual-stack/lib/components/PageHeader';
+import {PageHeader, PageTitle,} from '@cjdev/visual-stack/lib/components/PageHeader';
 import PageContent from '@cjdev/visual-stack/lib/components/PageContent';
 
 class DialogLayoutParent extends React.Component {
@@ -57,6 +42,23 @@ class DialogLayoutParent extends React.Component {
                   </Body>
                 </Panel>
                 <Panel>
+                  <Header>Full page wide DialogLayout Demo</Header>
+                  <Body>
+                  <Button
+                    type="solid-primary"
+                    onClick={() => this.props.router.push('/wideDialogLayout')}
+                  >
+                    Show the DialogLayout with wide width
+                  </Button>
+                  <p>
+                    Sometimes you want the DialogLayout to take the full width of the page.
+                    You can pass the contentSize property with value 'wide' to get a full width
+                    DialogLayout.
+                  </p>
+                  <Snippet tag="s6" src={snippets} />
+                  </Body>
+                </Panel>
+                <Panel>
                   <Header>Submitting page DialogLayout Demo</Header>
                   <Body>
                     <Button
@@ -75,20 +77,21 @@ class DialogLayoutParent extends React.Component {
                   </Body>
                 </Panel>
                 <Panel>
-                  <Header>DialogLayout with no footer buttons</Header>
+                  <Header>DialogLayout with no submit/cancel buttons</Header>
                   <Body>
                     <Button
                       type="solid-primary"
                       onClick={() =>
-                        this.props.router.push('/noFooterDialogLayout')
+                        this.props.router.push('/noButtonDialogLayout')
                       }
                     >
-                      Show the DialogLayout with no footer
+                      Show the DialogLayout with no submit/cancel button, but instead an X
                     </Button>
                     <p>
-                      On readonly views, you might not want buttons at the
-                      bottom. If you don't pass text for these buttons, they
-                      won't render.
+                      On readonly views, you might not have an action you want to perform.
+                      If you don't pass text for the submit and cancel buttons, they won't render.
+                      If neither button is showing, an X will appear instead that will take the
+                      behavior of the cancel button.
                     </p>
                     <Snippet tag="s5" src={snippets} />
                   </Body>
@@ -159,7 +162,7 @@ export const SubmittingDialogLayoutDemo = ({ router }) => (
 /* s4:end */
 
 /* s5:start */
-export const NoFooterDialogLayoutDemo = ({ router }) => (
+export const NoButtonDialogLayoutDemo = ({ router }) => (
   <div>
     <DialogLayout
       title={'Create Program Term'}
@@ -174,6 +177,27 @@ export const NoFooterDialogLayoutDemo = ({ router }) => (
   </div>
 );
 /* s5:end */
+
+/* s6:start */
+export const WideDialogLayoutDemo = ({ router }) => (
+  <div>
+    <DialogLayout
+      title={'Create Program Term'}
+      submitButtonText={'Save Program Terms'}
+      cancelButtonText={'cancel'}
+      onCancel={() => router.push('/layouts/dialogLayout')}
+      onSubmit={() => {
+        alert('Success!'); // eslint-disable-line no-alert
+        router.push('/layouts/dialogLayout');
+      }}
+      logo={<CJLogo />}
+      contentSize={'wide'}
+    >
+      <DemoForm />
+    </DialogLayout>
+  </div>
+);
+/* s6:end */
 
 const NotRenderedComponent = () => (
   /* s3:start */

--- a/packages/visual-stack-docs/src/index.js
+++ b/packages/visual-stack-docs/src/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { browserHistory, IndexRoute, Route, Router } from 'react-router';
-import { combineReducers, createStore } from 'redux';
-import { Provider } from 'react-redux';
+import {browserHistory, IndexRoute, Route, Router} from 'react-router';
+import {combineReducers, createStore} from 'redux';
+import {Provider} from 'react-redux';
 
-import { reducer as vsReducer } from '@cjdev/visual-stack-redux';
+import {reducer as vsReducer} from '@cjdev/visual-stack-redux';
 import '@cjdev/visual-stack/lib/global';
 
 import App from './containers/App/';
@@ -12,13 +12,14 @@ import Home from './containers/Home/';
 import Components from './containers/Components/';
 import ComponentDocs from './containers/Components/Docs/';
 import Icons from './containers/Icons/';
-import Layouts, { LayoutsDocs } from './containers/Layouts';
+import Layouts, {LayoutsDocs} from './containers/Layouts';
 import GettingStarted from './containers/GettingStarted/';
 import './index.css';
 import {
   DialogLayoutDemo,
-  NoFooterDialogLayoutDemo,
+  NoButtonDialogLayoutDemo,
   SubmittingDialogLayoutDemo,
+  WideDialogLayoutDemo,
 } from './containers/Layouts/DialogLayout';
 
 const reducer = combineReducers({
@@ -52,8 +53,12 @@ ReactDOM.render(
         component={SubmittingDialogLayoutDemo}
       />
       <Route
-        path="/noFooterDialogLayout"
-        component={NoFooterDialogLayoutDemo}
+        path="/noButtonDialogLayout"
+        component={NoButtonDialogLayoutDemo}
+      />
+      <Route
+        path="/wideDialogLayout"
+        component={WideDialogLayoutDemo}
       />
     </Router>
   </Provider>,

--- a/packages/visual-stack/src/layouts/DialogLayout/index.css
+++ b/packages/visual-stack/src/layouts/DialogLayout/index.css
@@ -6,7 +6,7 @@
   width: 100%;
   height: 72px;
   padding: 16px 16px 24px;
-  background: #fff;
+  background: #4d5051;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.16);
   z-index: 20;
 }
@@ -23,12 +23,14 @@
   width: 40px;
   height: 40px;
   margin-top: -6px;
+  fill: #fff;
 }
 
 .vs-dialog-layout-page-title .vs-dialog-layout-title {
   display: inline-block;
   margin: 0;
   font-size: 2.2rem;
+  color: #fff;
 }
 
 .vs-dialog-layout-page-title .vs-dialog-layout-icon-close {
@@ -36,47 +38,51 @@
   margin-top: 4px;
   width: 32px;
   height: 32px;
-  fill: #333;
+  fill: #fff;
   opacity: 0.6;
   transition: 0.2s all ease-in-out;
   cursor: pointer;
 }
 .vs-dialog-layout-page-title .vs-dialog-layout-icon-close:hover {
   opacity: 1;
-  fill: #333;
+  fill: #fff;
 }
 
 .vs-dialog-layout-content {
   position: relative;
-  padding: 112px 24px;
   margin: 0 auto;
   z-index: 10;
-  max-width: 800px;
 }
 
 .vs-dialog-layout-content p {
   max-width: 580px;
 }
 
-.vs-dialog-layout-footer {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
-  height: 64px;
-  background: #48535f;
-  color: #fff;
-  text-align: right;
-  padding: 8px;
-  box-shadow: 0 -2px 3px rgba(0, 0, 0, 0.16);
-  z-index: 20;
+.vs-dialog-layout-content-normal {
+  max-width: 800px;
+  padding: 112px 24px 24px;
 }
-.vs-dialog-layout-footer .vs-text-btn {
+
+.vs-dialog-layout-content-wide {
+  max-width: 100%;
+  padding: 112px 48px 48px;
+}
+
+.vs-dialog-layout-button-bar .vs-text-btn {
   color: #fff;
   opacity: 0.64;
 }
-.vs-dialog-layout-footer .vs-text-btn:hover {
+.vs-dialog-layout-button-bar .vs-text-btn:hover {
   color: #fff;
   opacity: 1;
+}
+
+.vs-dialog-layout-button-bar {
+  text-align: right;
+  float: right;
+  display: inline-block;
+}
+
+.vs-dialog-layout-button-bar .vs-btn-d {
+  margin: 0 0 0 8px;
 }

--- a/packages/visual-stack/src/layouts/DialogLayout/index.js
+++ b/packages/visual-stack/src/layouts/DialogLayout/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Button } from '../../components/Button';
+import {Button} from '../../components/Button';
 import CloseIcon from 'mdi-react/CloseIcon';
+import cn from 'classnames';
 
 import './index.css';
 import Spinner from '../../components/Spinner';
@@ -23,40 +24,45 @@ export const DialogLayout = ({
   submitButtonText,
   disableSubmit,
   showSubmitButtonSpinner,
+  contentSize,
   logo,
   onCancel,
   onSubmit,
   children,
 }) => (
-  <div className={`vs-dialog-layout ${className ? className : ''}`}>
+  <div className={cn(`vs-dialog-layout`, className)}>
     <div className="vs-dialog-layout-header">
       <div className="vs-dialog-layout-page-title">
         <div className="vs-dialog-layout-logo-container">
           <span className="vs-cj-logo">{logo}</span>
         </div>
+
         <h1 className="vs-dialog-layout-title">{title}</h1>
-        <CloseIcon className="vs-dialog-layout-icon-close" onClick={onCancel} />
+
+        <div className="vs-dialog-layout-button-bar">
+          {cancelButtonText && (
+            <Button id="vs-dialog-layout-cancel" type="text" onClick={onCancel}>
+              {cancelButtonText}
+            </Button>
+          )}
+
+          {submitButtonText && (
+            <Button
+              id="vs-dialog-layout-submit"
+              type="solid-primary"
+              disabled={disableSubmit === true}
+              onClick={onSubmit}
+            >
+              {getSubmitButtonText(submitButtonText, showSubmitButtonSpinner)}
+            </Button>
+          )}
+          {!submitButtonText && !cancelButtonText &&
+            <CloseIcon className="vs-dialog-layout-icon-close" onClick={onCancel}/>
+          }
+        </div>
       </div>
     </div>
-    <div className="vs-dialog-layout-content">{children}</div>
-    <div className="vs-dialog-layout-footer">
-      {cancelButtonText && (
-        <Button id="vs-dialog-layout-cancel" type="text" onClick={onCancel}>
-          {cancelButtonText}
-        </Button>
-      )}
-
-      {submitButtonText && (
-        <Button
-          id="vs-dialog-layout-submit"
-          type="solid-primary"
-          disabled={disableSubmit === true}
-          onClick={onSubmit}
-        >
-          {getSubmitButtonText(submitButtonText, showSubmitButtonSpinner)}
-        </Button>
-      )}
-    </div>
+    <div className={cn("vs-dialog-layout-content", `vs-dialog-layout-content-${contentSize ? contentSize : 'normal'}`)}>{children}</div>
   </div>
 );
 

--- a/packages/visual-stack/src/layouts/DialogLayout/tests/index.test.js
+++ b/packages/visual-stack/src/layouts/DialogLayout/tests/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Enzyme, { mount, shallow } from 'enzyme';
+import Enzyme, {mount, shallow} from 'enzyme';
 import DialogLayout from '../';
 import Adapter from 'enzyme-adapter-react-16';
 
@@ -67,6 +67,14 @@ describe('DialogLayout', () => {
     expect(cancelButton).toHaveLength(0);
   });
 
+  test('should show the X button when neither of the other buttons shown', () => {
+    const component = shallow(<DialogLayout />);
+
+    const closeIconButton = component.find('.vs-dialog-layout-icon-close');
+
+    expect(closeIconButton).toHaveLength(1);
+  });
+
   test('should call cancel handler when cancel button is clicked', () => {
     let onCancel = false;
     const onClickFake = () => {
@@ -91,7 +99,7 @@ describe('DialogLayout', () => {
     };
 
     const component = shallow(
-      <DialogLayout onCancel={onClickFake} cancelButtonText="Cancel" />
+      <DialogLayout onCancel={onClickFake} />
     );
 
     const closeIcon = component.find('.vs-dialog-layout-icon-close');
@@ -132,5 +140,39 @@ describe('DialogLayout', () => {
 
     expect(submitButton.find('Spinner').length).toEqual(1);
     expect(submitButton.at(0).text()).toEqual(' ' + submitButtonText);
+  });
+
+  test('should have wide content when contentSize is wide', () => {
+    const component = mount(
+      <DialogLayout
+        contentSize={'wide'}
+      />
+    );
+
+    const content = component.find('.vs-dialog-layout-content');
+
+    expect(content.hasClass('vs-dialog-layout-content-wide')).toBe(true);
+  });
+
+  test('should have normal content when contentSize is normal', () => {
+    const component = mount(
+      <DialogLayout
+        contentSize={'normal'}
+      />
+    );
+
+    const content = component.find('.vs-dialog-layout-content');
+
+    expect(content.hasClass('vs-dialog-layout-content-normal')).toBe(true);
+  });
+
+  test('should have normal content when contentSize is not passed', () => {
+    const component = mount(
+      <DialogLayout/>
+    );
+
+    const content = component.find('.vs-dialog-layout-content');
+
+    expect(content.hasClass('vs-dialog-layout-content-normal')).toBe(true);
   });
 });


### PR DESCRIPTION
- Remove footer from DialogLayout and move buttons to the top
- X button now appears only when both submit and cancel aren't shown
- Changed color of the header to match CJAM
- Added contentSize property to allow full-width (wide) vs narrow (normal) content size, defaulted to normal