### PR TITLE
Improve ButtonWithDropdown

### DIFF
--- a/packages/visual-stack-docs/src/containers/Components/Docs/button-with-dropdown.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/button-with-dropdown.js
@@ -14,7 +14,7 @@ export default () => (
       return (
         <div>
           <Panel>
-            <Header>Button with Dropdown Area</Header>
+            <Header>Button with Dropdown</Header>
             <Body>
               <Snippet tag="s1" src={snippets} />
               <p>

--- a/packages/visual-stack-docs/src/containers/Components/Docs/button-with-dropdown.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/button-with-dropdown.js
@@ -14,7 +14,7 @@ export default () => (
       return (
         <div>
           <Panel>
-            <Header>Blank Slate</Header>
+            <Header>Button with Dropdown Area</Header>
             <Body>
               <Snippet tag="s1" src={snippets} />
               <p>
@@ -60,7 +60,7 @@ class DropdownContainer extends React.Component {
         expanded={this.state.expanded}
         doExpand={() => this.doExpand()}
         ButtonComponent={CustomButton}
-        buttonContent="Expanded"
+        buttonContent="Expand"
         className="dropdown-demo"
         id="range-dropdown"
       >

--- a/packages/visual-stack/src/components/ButtonWithDropdown/index.js
+++ b/packages/visual-stack/src/components/ButtonWithDropdown/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Button } from '../Button.js';
 
 import './styles.css';
 
@@ -9,18 +10,16 @@ export const ButtonWithDropdown = ({
   buttonContent,
   children,
   className = '',
-  ButtonComponent,
+  renderButton = props => <Button {...props} />,
   ...rest
 }) => (
-  <div className="vs-dropdown-with-button">
-    <ButtonComponent
-      {...rest}
-      expanded={expanded}
-      className={className}
-      onClick={doExpand}
-    >
-      {buttonContent}
-    </ButtonComponent>
+  <div {...rest} className={`vs-dropdown-with-button ${className}`}>
+    {renderButton({
+      expanded,
+      className: `vs-dropdown-with-button-button ${className}-button`,
+      onClick: doExpand,
+      children: buttonContent,
+    })}
 
     <div className={['vs-dropdown', expanded ? 'vs-visible' : ''].join(' ')}>
       {children}
@@ -33,8 +32,5 @@ ButtonWithDropdown.propTypes = {
   buttonContent: PropTypes.node,
   children: PropTypes.node,
   className: PropTypes.string,
-  ButtonComponent: PropTypes.node,
-};
-ButtonWithDropdown.defaultProps = {
-  ButtonComponent: 'button',
+  renderButton: PropTypes.func,
 };

--- a/packages/visual-stack/src/components/ButtonWithDropdown/index.js
+++ b/packages/visual-stack/src/components/ButtonWithDropdown/index.js
@@ -10,7 +10,7 @@ export const ButtonWithDropdown = ({
   buttonContent,
   children,
   className = '',
-  renderButton = props => <Button {...props} />,
+  renderButton = props => <Button type="solid-primary" {...props} />,
   ...rest
 }) => (
   <div {...rest} className={`vs-dropdown-with-button ${className}`}>

--- a/packages/visual-stack/src/components/ButtonWithDropdown/tests/index.test.js
+++ b/packages/visual-stack/src/components/ButtonWithDropdown/tests/index.test.js
@@ -57,19 +57,22 @@ describe('ButtonWithDropDown', () => {
 
     expect(
       component
-        .find('button')
+        .find('.newClass-button')
+        .shallow()
         .text()
         .slice(0, 2)
     ).toEqual('hi');
-    expect(component.find('button').prop('onClick')).toEqual(doExpand);
-    expect(component.find('button').prop('className')).toEqual('newClass');
-    expect(component.find('button').prop('id')).toEqual('id');
+    expect(component.find('.newClass-button').prop('onClick')).toEqual(
+      doExpand
+    );
+    expect(component.prop('className')).toMatch(/.*\bnewClass\b.*/);
+    expect(component.prop('id')).toEqual('id');
     expect(component.find('.vs-dropdown #target')).toHaveLength(1);
   });
 
-  test('uses ButtonComponent prop', () => {
+  test('uses renderButton render prop', () => {
     const doExpand = () => {};
-    const ButtonComponent = _props => <div id="button" />;
+    const renderButton = props => <div {...props} id="button" />;
     const component = shallow(
       <uut.ButtonWithDropdown
         expanded={true}
@@ -78,14 +81,16 @@ describe('ButtonWithDropDown', () => {
         className="newClass"
         id="id"
         styles={getStyles()}
-        ButtonComponent={ButtonComponent}
+        renderButton={renderButton}
       >
         <div id="target" />
       </uut.ButtonWithDropdown>
     );
 
-    const button = component.find(ButtonComponent);
+    const button = component.find('#button');
     expect(button).toHaveLength(1);
     expect(button.prop('expanded')).toEqual(true);
+    expect(button.prop('onClick')).toEqual(doExpand);
+    expect(button.text()).toEqual('hi');
   });
 });


### PR DESCRIPTION
Use a render prop for the button instead of passing in a component: this makes 
it easier to specify how the button renders without having to worry about React's 
rules around component identity (see the date picker PR for an example).

Also, fixes issue @fhwrdh noticed here, also tweak the button text in the docs: https://github.com/cjdev/visual-stack/pull/182#issuecomment-493713780


<img width="1226" alt="image" src="https://user-images.githubusercontent.com/808745/57976348-7b294880-7992-11e9-9bf7-2ead14b0e506.png">
