### PR TITLE
Remove inner submenu ul max-height to show all menu links

### DIFF
--- a/packages/visual-stack/src/components/SideNav/SideNav.css
+++ b/packages/visual-stack/src/components/SideNav/SideNav.css
@@ -264,15 +264,15 @@
 }
 
 .vs-sidenav .vs-sidenav-container ul {
-  height: 0;
+  max-height: 0;
   overflow: hidden;
-  /*   transition: .3s max-height ease-in-out; */
-  transition: 0.4s all cubic-bezier(0.22, 0.61, 0.36, 1);
+  transition: .3s max-height ease-in-out;
+  /* transition: 0.4s all cubic-bezier(0.22, 0.61, 0.36, 1); */
   padding: 0;
 }
 
 .vs-sidenav .vs-sidenav-container.expanded ul {
-  height: auto;
+  max-height: 960px;
 }
 
 .vs-sidenav.collapsed .vs-sidenav-header,

--- a/packages/visual-stack/src/components/SideNav/SideNav.css
+++ b/packages/visual-stack/src/components/SideNav/SideNav.css
@@ -264,15 +264,15 @@
 }
 
 .vs-sidenav .vs-sidenav-container ul {
-  max-height: 0;
+  height: 0;
   overflow: hidden;
   /*   transition: .3s max-height ease-in-out; */
-  transition: 0.4s max-height cubic-bezier(0.22, 0.61, 0.36, 1);
+  transition: 0.4s all cubic-bezier(0.22, 0.61, 0.36, 1);
   padding: 0;
 }
 
 .vs-sidenav .vs-sidenav-container.expanded ul {
-  max-height: 768px;
+  height: auto;
 }
 
 .vs-sidenav.collapsed .vs-sidenav-header,


### PR DESCRIPTION
Currently set at max-height of 768px which cuts off the rest of the items. Example can be seen in visual-stack-docs/components/ (spinner, tablayout, table pages are hidden)