### PR TITLE
Passing in initialActive as true will call toggleSideNavLinkGroup

### DIFF
--- a/packages/visual-stack-redux/package-lock.json
+++ b/packages/visual-stack-redux/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cjdev/visual-stack-redux",
-	"version": "4.6.0",
+	"version": "4.7.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1152,9 +1152,9 @@
 			}
 		},
 		"@cjdev/visual-stack": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@cjdev/visual-stack/-/visual-stack-4.6.0.tgz",
-			"integrity": "sha512-LO9F3XOsJPYfEcJ1dprCtS3JI9k/1nBC1V1b04HBFAs9m5/HhtH6FFXeEiTzLRFq1X0nIpqGmVYceCInE204nA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@cjdev/visual-stack/-/visual-stack-4.7.0.tgz",
+			"integrity": "sha512-+0JwC79K8lLsIBtyIgfBExrHchMYoXTeQqnMLRVFjRZJymr5op0EFA7HCNFVZWlr3NPyVFZgOFIu13fobxX2jg==",
 			"dev": true,
 			"requires": {
 				"@material-ui/core": "^3.3.2",
@@ -2530,9 +2530,9 @@
 			}
 		},
 		"babel-plugin-macros": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz",
-			"integrity": "sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.0.tgz",
+			"integrity": "sha512-6hrXm6NIoSp+JiqhHZ6tUemhClnu//vjx9fAU5tkRCztTKxgiUpFpMDBX4yZiJIco7qkf0CPX2u4Ax3x6GCiUg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.2",

--- a/packages/visual-stack-redux/src/components/SideNav/LinkGroup.js
+++ b/packages/visual-stack-redux/src/components/SideNav/LinkGroup.js
@@ -13,7 +13,11 @@ export class InternalLinkGroup extends Component {
   };
   constructor(props) {
     super(props);
+      if (this.props.initialActive) {
+          this.props.toggleSideNavLinkGroup(this.props.initialActive, this.props.label);
+      }
   }
+
   render() {
     const expanded =
       R.view(

--- a/packages/visual-stack-redux/test/components/SideNav/LinkGroup.test.js
+++ b/packages/visual-stack-redux/test/components/SideNav/LinkGroup.test.js
@@ -22,6 +22,24 @@ describe('LinkGroup', () => {
     expect(wrapper.find(LinkGroup).prop('label')).toBe('whatever');
   });
 
+  test('should call toggleSideNavLinkGroup to toggle expanded when initialActive is passed in to component', () => {
+    const label = 'LABEL';
+    const state = {};
+    const toggleSideNavLinkGroupSpy = sinon.spy();
+    mount(
+      <InternalLinkGroup
+        label={label}
+        linkGroups={state}
+        toggleSideNav={() => {}}
+        toggleSideNavLinkGroup={toggleSideNavLinkGroupSpy}
+        initialActive={true}
+      />
+    );
+
+    sinon.assert.calledOnce(toggleSideNavLinkGroupSpy);
+
+  });
+
   test('should calculate expanded value based on state', () => {
     const label = 'LABEL';
     const state = {


### PR DESCRIPTION
We'd like to be able to pass a prop to LinkGroups that makes the expanded state enabled by default