### PR TITLE
Datepicker cb named ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Upcoming
+## New Feature
+- The callback for the datepicker now gets the ids of the currently selected sidebar ranges
+
 # 4.8.0
 ## New Feature
 - Add Button type "inline-outline-secondary" for Buttons that are lined up in a row with selects.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap && lerna run build",
     "start-all": "npm run bootstrap && npx foreman start",
+    "start-all-fast": "npx foreman start",
     "link": "(cd packages/visual-stack && npm link) && (cd packages/visual-stack-redux && npm link)",
     "lint": "lerna run lint",
     "test": "export CI=true; lerna run test",

--- a/packages/visual-stack-docs/src/containers/Components/Docs/datepicker.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/datepicker.js
@@ -327,15 +327,18 @@ export default () => {
                 <p>
                   The predefined ranges are defined using{' '}
                   <code>sidebarSection</code>, <code>sectionTitle</code> and{' '}
-                  <code>sectionRange</code> (see the examples for usage). The
-                  named ranges can each be specified as a list of start and end
-                  dates in the format <code>yyyy-mm-dd</code>, or a function can
-                  be passed that gets all the currently selected ranges (from
-                  both calendars) and returns a single range for the calendar
-                  corresponding to the sidebar section.
+                  <code>
+                    sectionRange(selectedRanges, curIdx, selectedNamedRangeIds)
+                  </code>{' '}
+                  (see the examples for usage). The named ranges can each be
+                  specified as a list of start and end dates in the format{' '}
+                  <code>yyyy-mm-dd</code>, or a function can be passed that gets
+                  all the currently selected ranges (from both calendars) and
+                  returns a single range for the calendar corresponding to the
+                  sidebar section.
                 </p>
                 <p>
-                  There are two special named intervals: <code>custom</code> and{' '}
+                  There are two special named ranges: <code>custom</code> and{' '}
                   <code>none</code>. If calendar is manipulated directly, the{' '}
                   <code>custom</code> range is selected. If <code>none</code> is
                   selected, the corresponding calendar is hidden.


### PR DESCRIPTION
The callback for the datepicker now gets the ids of the currently selected sidebar ranges.  This is a backwards-compatible change because we added an argument to the callback.