### PR TITLE
SlidingPanel and SlidingPanelDropdown now respect state

### DIFF
--- a/packages/visual-stack-redux/test/actions.test.js
+++ b/packages/visual-stack-redux/test/actions.test.js
@@ -18,7 +18,7 @@ import reducer, {
   setDataTablePage,
   setDataTableSortingOption,
 } from '../src/actions';
-import { selectDataTable } from '../lib/actions';
+import { selectDataTable } from '../src/actions';
 import { DESCENDING } from '@cjdev/visual-stack/lib/components/Table/DataTable/sortingHelper';
 
 describe('reducer', () => {

--- a/packages/visual-stack-redux/test/components/SlidingPanel.test.js
+++ b/packages/visual-stack-redux/test/components/SlidingPanel.test.js
@@ -6,6 +6,8 @@ import {
   InternalSlidingPanel,
   InternalToggleIcon,
   InternalSlidingPanelDropdown,
+  slidingPanelStateToProps,
+  slidingPanelDropdownStateToProps,
 } from '../../src/components/SlidingPanel';
 import {
   SlidingPanel,
@@ -15,6 +17,7 @@ import {
 
 import Adapter from 'enzyme-adapter-react-16';
 import Enzyme from 'enzyme';
+
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('SlidingPanel', () => {
@@ -36,6 +39,48 @@ describe('SlidingPanel', () => {
         </InternalSlidingPanel>
       );
       expect(wrapper.find(SlidingPanelHeader)).toHaveLength(1);
+    });
+
+    test('slidingPanelStateToProps should use initialActive when no state is passed', () => {
+      // given
+      const state = { visualStack: { slidingPanel: { active: undefined } } };
+      const props = { initialActive: true };
+
+      // when
+      const calculatedProps = slidingPanelStateToProps(state, props);
+      // then
+      expect(calculatedProps).toMatchObject({
+        active: true,
+        syncStateToOpen: true,
+      });
+    });
+
+    test('slidingPanelStateToProps should use its own state when not undefined', () => {
+      // given
+      const state = { visualStack: { slidingPanel: { active: false } } };
+      const props = { initialActive: true };
+
+      // when
+      const calculatedProps = slidingPanelStateToProps(state, props);
+      // then
+      expect(calculatedProps).toMatchObject({
+        active: false,
+        syncStateToOpen: false,
+      });
+    });
+
+    test('slidingPanelStateToProps should not syncstateToOpen when initialActive falsy', () => {
+      // given
+      const state = { visualStack: { slidingPanel: { active: undefined } } };
+      const props = { initialActive: false };
+
+      // when
+      const calculatedProps = slidingPanelStateToProps(state, props);
+      // then
+      expect(calculatedProps).toMatchObject({
+        active: false,
+        syncStateToOpen: false,
+      });
     });
   });
 
@@ -67,13 +112,14 @@ describe('SlidingPanel', () => {
       expect(dropdown.props().label).toBe(title);
     });
 
-    test('should render children when Dropdown is expanded', () => {
-      const hideFilterDropdown = jest.fn();
+    test('should call expandFilterDropdown when syncStateToOpen is truthy', () => {
+      const expandFilterDropdown = jest.fn();
       const slidingPanel = mount(
         <InternalSlidingPanelDropdown
           label="MyCids"
           id="test_dropdown"
-          hideFilterDropdown={hideFilterDropdown}
+          syncStateToOpen
+          expandFilterDropdown={expandFilterDropdown}
         >
           <div>Something</div>
         </InternalSlidingPanelDropdown>
@@ -85,30 +131,53 @@ describe('SlidingPanel', () => {
       expect(
         dropdown.find('div.vs-sliding-panel-section-options')
       ).toHaveLength(1);
-
-      expect(hideFilterDropdown.mock.calls).toHaveLength(1);
+      expect(expandFilterDropdown.mock.calls).toHaveLength(1);
     });
-  });
 
-  test('should expand filter dropdown when initialActive is true', () => {
-    const expandFilterDropdown = jest.fn();
-    const slidingPanel = mount(
-      <InternalSlidingPanelDropdown
-        label="MyCids"
-        id="test_dropdown"
-        initialActive
-        expandFilterDropdown={expandFilterDropdown}
-      >
-        <div>Something</div>
-      </InternalSlidingPanelDropdown>
-    );
-    const dropdown = slidingPanel.find(SlidingPanelDropdown);
-    dropdown
-      .find('a.vs-sliding-panel-section-container-label')
-      .simulate('click');
-    expect(dropdown.find('div.vs-sliding-panel-section-options')).toHaveLength(
-      1
-    );
-    expect(expandFilterDropdown.mock.calls).toHaveLength(1);
+    test('slidingPanelDropdownStateToProps should use own state if not undefined', () => {
+      // given
+      const state = {
+        visualStack: { slidingPanel: { foo: { expanded: false } } },
+      };
+      const props = { initialActive: true, id: 'foo' };
+
+      // when
+      const calculatedProps = slidingPanelDropdownStateToProps(state, props);
+      // then
+      expect(calculatedProps).toMatchObject({
+        expanded: false,
+        syncStateToOpen: false,
+      });
+    });
+
+    test('slidingPanelDropdownStateToProps should use initalActive if state is undefined', () => {
+      // given
+      const state = { visualStack: { slidingPanel: {} } };
+      const props = { initialActive: 'bar', id: 'foo' };
+
+      // when
+      const calculatedProps = slidingPanelDropdownStateToProps(state, props);
+      // then
+      expect(calculatedProps).toMatchObject({
+        expanded: 'bar',
+        syncStateToOpen: true,
+      });
+    });
+
+    test('slidingPanelDropdownStateToProps should not syncStateToOpen when it has state', () => {
+      // given
+      const state = {
+        visualStack: { slidingPanel: { foo: { expanded: 'baz' } } },
+      };
+      const props = { initialActive: true, id: 'foo' };
+
+      // when
+      const calculatedProps = slidingPanelDropdownStateToProps(state, props);
+      // then
+      expect(calculatedProps).toMatchObject({
+        expanded: 'baz',
+        syncStateToOpen: false,
+      });
+    });
   });
 });


### PR DESCRIPTION
Both of these components had a bug where if they were destroyed and brought back (i.e. switching routes on a multi-page app) they would lose state if you used intiial active.

I changed it to use initialActive only when state coming from the store is undefined, otherwise it respects the stored state even if for some reason the constructor is called again.