### PR TITLE
DataTable/Pagination changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Upcoming
 ## Bug Fixes
 - Fix styling on DataTable cells not matching the corresponding header styles
+- Allow SideNav to have any number of children under the fold
 ## Update Dependency
 - Updated react-svg to v10 to fix React 16.9 warnings about deprecated lifecycle methods
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Upcoming
+## Bug Fixes
+- Fix styling on DataTable cells not matching the corresponding header styles
+## Update Dependency
+- Updated react-svg to v10 to fix React 16.9 warnings about deprecated lifecycle methods
 
 # 4.11.1
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 ## Bug Fixes
 - Fix styling on DataTable cells not matching the corresponding header styles
 - Allow SideNav to have more children under the fold
+- Pagination with 0 entries now correctly displays total pages
+## New Feature
+- Better handle empty DataTables with a new configurable message
+- Add ability to change hard-coded text in Pagination for customization and translations
+- Add ability for DataTables to change hard-coded text in Pagination
 ## Update Dependency
 - Updated react-svg to v10 to fix React 16.9 warnings about deprecated lifecycle methods
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Upcoming
 ## Bug Fixes
 - Fix styling on DataTable cells not matching the corresponding header styles
-- Allow SideNav to have any number of children under the fold
+- Allow SideNav to have more children under the fold
 ## Update Dependency
 - Updated react-svg to v10 to fix React 16.9 warnings about deprecated lifecycle methods
 

--- a/packages/visual-stack-docs/src/containers/Components/Docs/pagination.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/pagination.js
@@ -52,7 +52,7 @@ class PaginationDocs extends React.Component {
                     onChange={paginationValue => {
                       letTheServerKnow(paginationValue);
                     }}
-                    numberOfRowsTemplate={"display {0}"}
+                    rowsPerPageTemplate={"display {0}"}
                     totalRecordsTemplate={"I have {0} things"}
                   />
                   {/* s3:end */}

--- a/packages/visual-stack-docs/src/containers/Components/Docs/pagination.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/pagination.js
@@ -39,6 +39,25 @@ class PaginationDocs extends React.Component {
                   {/* s2:end */}
                 </Body>
               </Panel>
+
+              <Panel>
+                <Header>Pagination with translations</Header>
+                <Body>
+                  <Snippet tag="s3" src={snippets} />
+                  <pre>Server Received: {JSON.stringify(this.state)}</pre>
+                  {/* s3:start */}
+                  <Pagination
+                    paginationId="pagination-example-with-translation"
+                    numberOfRows={250}
+                    onChange={paginationValue => {
+                      letTheServerKnow(paginationValue);
+                    }}
+                    numberOfRowsTemplate={"display {0}"}
+                    totalRecordsTemplate={"I have {0} things"}
+                  />
+                  {/* s3:end */}
+                </Body>
+              </Panel>
             </div>
           );
         }}

--- a/packages/visual-stack-docs/src/containers/Components/Docs/table.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/table.js
@@ -163,7 +163,7 @@ export default () => (
           {/* s9:start */}
           <DataTable
             id="sample-empty-data-table"
-            caption="Empty Sortable Data Table with Pagination"
+            caption="Empty Sortable Data Table with Pagination and translations"
             description="Description Text"
             columns={[
               { label: 'ID', width: '9%', clickable: true },
@@ -210,6 +210,8 @@ export default () => (
               </Fragment>
             )}
             noDataLabel="example no data message (default: 'No data available.')"
+            numberOfRowsTemplate="{0} on a page"
+            totalRecordsTemplate="There are {0} total records"
             sortable
             pagination
           />
@@ -219,7 +221,8 @@ export default () => (
             <Header>Empty Sortable Data Table with Pagination Example</Header>
             <Body>
               <div className="docs">
-                This shows the data table when there is no data
+                This shows the data table when there is no data. This also shows
+                translation template props for any hard-coded text within the component.
               </div>
               <Snippet tag="s9" src={snippets} />
             </Body>

--- a/packages/visual-stack-docs/src/containers/Components/Docs/table.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/table.js
@@ -210,7 +210,7 @@ export default () => (
               </Fragment>
             )}
             noDataLabel="example no data message (default: 'No data available.')"
-            numberOfRowsTemplate="{0} on a page"
+            rowsPerPageTemplate="{0} on a page"
             totalRecordsTemplate="There are {0} total records"
             sortable
             pagination

--- a/packages/visual-stack-docs/src/containers/Components/Docs/table.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/table.js
@@ -160,6 +160,71 @@ export default () => (
             </Body>
           </Panel>
 
+          {/* s9:start */}
+          <DataTable
+            id="sample-empty-data-table"
+            caption="Empty Sortable Data Table with Pagination"
+            description="Description Text"
+            columns={[
+              { label: 'ID', width: '9%', clickable: true },
+              { label: 'First Name', width: '16%', clickable: true },
+              { label: 'Last Name', width: '39%' },
+              { label: 'Rank', width: '14%' },
+              {
+                label: 'Change',
+                width: '11%',
+                renderCell: renderTrend,
+              },
+              {
+                label: 'Custom Change',
+                width: '11%',
+                renderCell: renderCustomTrend,
+              },
+            ]}
+            data={[]}
+            onClick={e => {
+              window.alert(`You click on a cell: ${JSON.stringify(e)}`);
+            }}
+            sortingOption={{
+              label: 'Rank',
+              order: DESCENDING,
+            }}
+            renderToolbar={({ data, columns }) => (
+              <Fragment>
+                <Button
+                  onClick={() => {
+                    window.alert(JSON.stringify(columns));
+                  }}
+                  type="outline-secondary"
+                >
+                  columns
+                </Button>
+                <Button
+                  onClick={() => {
+                    window.alert(JSON.stringify(data));
+                  }}
+                  type="outline-secondary"
+                >
+                  data
+                </Button>
+              </Fragment>
+            )}
+            noDataLabel="example no data message (default: 'No data available.')"
+            sortable
+            pagination
+          />
+          {/* s9:end */}
+
+          <Panel>
+            <Header>Empty Sortable Data Table with Pagination Example</Header>
+            <Body>
+              <div className="docs">
+                This shows the data table when there is no data
+              </div>
+              <Snippet tag="s9" src={snippets} />
+            </Body>
+          </Panel>
+
           <Panel>
             <Header>Simple Table</Header>
             <Body>

--- a/packages/visual-stack-redux/src/components/DataTable/index.js
+++ b/packages/visual-stack-redux/src/components/DataTable/index.js
@@ -42,6 +42,7 @@ export class DataTablePure extends Component {
       columns,
       caption,
       description,
+      noDataLabel,
       dataTable,
       pagination,
       id,
@@ -56,6 +57,7 @@ export class DataTablePure extends Component {
           onClick={onClick}
           caption={caption}
           description={description}
+          noDataLabel={noDataLabel}
           sortable={sortable}
           pagination={pagination}
           data={dataTable.data}

--- a/packages/visual-stack-redux/src/components/DataTable/index.js
+++ b/packages/visual-stack-redux/src/components/DataTable/index.js
@@ -50,7 +50,7 @@ export class DataTablePure extends Component {
       setDataTableSortingOption,
       onClick,
       renderToolbar,
-      numberOfRowsTemplate,
+      rowsPerPageTemplate,
       totalRecordsTemplate,
     } = this.props;
     return (
@@ -74,7 +74,7 @@ export class DataTablePure extends Component {
             setDataTableSortingOption({ id, data, sortingOption });
           }}
           renderToolbar={renderToolbar}
-          numberOfRowsTemplate={numberOfRowsTemplate}
+          rowsPerPageTemplate={rowsPerPageTemplate}
           totalRecordsTemplate={totalRecordsTemplate}
         />
       </div>
@@ -106,7 +106,7 @@ DataTablePure.propTypes = {
   setDataTableSortingOption: PropTypes.func,
   onClick: PropTypes.func,
   renderToolBar: PropTypes.func,
-  numberOfRowsTemplate: PropTypes.string,
+  rowsPerPageTemplate: PropTypes.string,
   totalRecordsTemplate: PropTypes.string,
 };
 

--- a/packages/visual-stack-redux/src/components/DataTable/index.js
+++ b/packages/visual-stack-redux/src/components/DataTable/index.js
@@ -50,6 +50,8 @@ export class DataTablePure extends Component {
       setDataTableSortingOption,
       onClick,
       renderToolbar,
+      numberOfRowsTemplate,
+      totalRecordsTemplate,
     } = this.props;
     return (
       <div>
@@ -72,6 +74,8 @@ export class DataTablePure extends Component {
             setDataTableSortingOption({ id, data, sortingOption });
           }}
           renderToolbar={renderToolbar}
+          numberOfRowsTemplate={numberOfRowsTemplate}
+          totalRecordsTemplate={totalRecordsTemplate}
         />
       </div>
     );
@@ -81,6 +85,7 @@ export class DataTablePure extends Component {
 DataTablePure.propTypes = {
   caption: PropTypes.string,
   description: PropTypes.string,
+  noDataLabel: PropTypes.string,
   sortable: PropTypes.bool,
   pagination: PropTypes.bool,
   data: PropTypes.array,
@@ -101,6 +106,8 @@ DataTablePure.propTypes = {
   setDataTableSortingOption: PropTypes.func,
   onClick: PropTypes.func,
   renderToolBar: PropTypes.func,
+  numberOfRowsTemplate: PropTypes.string,
+  totalRecordsTemplate: PropTypes.string,
 };
 
 const mapStateToProps = (state, ownProps) => ({

--- a/packages/visual-stack-redux/src/components/DataTable/tests/index.test.js
+++ b/packages/visual-stack-redux/src/components/DataTable/tests/index.test.js
@@ -97,6 +97,8 @@ describe('DataTablePure', () => {
     };
     const caption = 'I am a table';
     const noDataLabel = "I have no data";
+    const numberOfRowsTemplate = "numberOfRowsTemplate";
+    const totalRecordsTemplate = "totalRecordsTemplate";
     const dataTable = {
       data,
       pagination: {
@@ -113,12 +115,13 @@ describe('DataTablePure', () => {
         sortable={sortable}
         pagination={pagination}
         data={[]}
-        dataTable={{ pagination: {} }}
         initializeDataTable={initializeDataTable}
         dataTable={dataTable}
         onClick={onClick}
         renderToolbar={renderToolbar}
         noDataLabel={noDataLabel}
+        numberOfRowsTemplate={numberOfRowsTemplate}
+        totalRecordsTemplate={totalRecordsTemplate}
       />
     );
     const props = wrapper.find(VSDataTable).props();
@@ -133,6 +136,8 @@ describe('DataTablePure', () => {
     expect(props.onClick).toEqual(onClick);
     expect(props.renderToolbar).toEqual(renderToolbar);
     expect(props.noDataLabel).toEqual(noDataLabel);
+    expect(props.numberOfRowsTemplate).toEqual(numberOfRowsTemplate);
+    expect(props.totalRecordsTemplate).toEqual(totalRecordsTemplate);
   });
 
   it('should not reset data table data if props isnt changed', () => {

--- a/packages/visual-stack-redux/src/components/DataTable/tests/index.test.js
+++ b/packages/visual-stack-redux/src/components/DataTable/tests/index.test.js
@@ -96,6 +96,7 @@ describe('DataTablePure', () => {
       order: 'ASCENDING',
     };
     const caption = 'I am a table';
+    const noDataLabel = "I have no data";
     const dataTable = {
       data,
       pagination: {
@@ -117,6 +118,7 @@ describe('DataTablePure', () => {
         dataTable={dataTable}
         onClick={onClick}
         renderToolbar={renderToolbar}
+        noDataLabel={noDataLabel}
       />
     );
     const props = wrapper.find(VSDataTable).props();
@@ -130,6 +132,7 @@ describe('DataTablePure', () => {
     expect(props.sortingOption).toEqual(dataTable.sortingOption);
     expect(props.onClick).toEqual(onClick);
     expect(props.renderToolbar).toEqual(renderToolbar);
+    expect(props.noDataLabel).toEqual(noDataLabel);
   });
 
   it('should not reset data table data if props isnt changed', () => {

--- a/packages/visual-stack-redux/src/components/DataTable/tests/index.test.js
+++ b/packages/visual-stack-redux/src/components/DataTable/tests/index.test.js
@@ -97,7 +97,7 @@ describe('DataTablePure', () => {
     };
     const caption = 'I am a table';
     const noDataLabel = "I have no data";
-    const numberOfRowsTemplate = "numberOfRowsTemplate";
+    const rowsPerPageTemplate = "rowsPerPageTemplate";
     const totalRecordsTemplate = "totalRecordsTemplate";
     const dataTable = {
       data,
@@ -120,7 +120,7 @@ describe('DataTablePure', () => {
         onClick={onClick}
         renderToolbar={renderToolbar}
         noDataLabel={noDataLabel}
-        numberOfRowsTemplate={numberOfRowsTemplate}
+        rowsPerPageTemplate={rowsPerPageTemplate}
         totalRecordsTemplate={totalRecordsTemplate}
       />
     );
@@ -136,7 +136,7 @@ describe('DataTablePure', () => {
     expect(props.onClick).toEqual(onClick);
     expect(props.renderToolbar).toEqual(renderToolbar);
     expect(props.noDataLabel).toEqual(noDataLabel);
-    expect(props.numberOfRowsTemplate).toEqual(numberOfRowsTemplate);
+    expect(props.rowsPerPageTemplate).toEqual(rowsPerPageTemplate);
     expect(props.totalRecordsTemplate).toEqual(totalRecordsTemplate);
   });
 

--- a/packages/visual-stack-redux/src/components/Pagination/index.js
+++ b/packages/visual-stack-redux/src/components/Pagination/index.js
@@ -23,6 +23,8 @@ export class PaginationPure extends React.Component {
       setPaginationValue,
       paginationId,
       onChange,
+      numberOfRowsTemplate,
+      totalRecordsTemplate,
     } = this.props;
     return (
       <Pagination
@@ -33,6 +35,8 @@ export class PaginationPure extends React.Component {
           onChange(paginationValue);
           setPaginationValue({ ...paginationValue, paginationId });
         }}
+        numberOfRowsTemplate={numberOfRowsTemplate}
+        totalRecordsTemplate={totalRecordsTemplate}
       />
     );
   }
@@ -44,6 +48,8 @@ PaginationPure.propTypes = {
   setPaginationValue: PropTypes.func.isRequired,
   paginationId: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  numberOfRowsTemplate: PropTypes.string,
+  totalRecordsTemplate: PropTypes.string,
 };
 
 const mapDispatchToProps = { initializePagination, setPaginationValue };

--- a/packages/visual-stack-redux/src/components/Pagination/index.js
+++ b/packages/visual-stack-redux/src/components/Pagination/index.js
@@ -23,7 +23,7 @@ export class PaginationPure extends React.Component {
       setPaginationValue,
       paginationId,
       onChange,
-      numberOfRowsTemplate,
+      rowsPerPageTemplate,
       totalRecordsTemplate,
     } = this.props;
     return (
@@ -35,7 +35,7 @@ export class PaginationPure extends React.Component {
           onChange(paginationValue);
           setPaginationValue({ ...paginationValue, paginationId });
         }}
-        numberOfRowsTemplate={numberOfRowsTemplate}
+        rowsPerPageTemplate={rowsPerPageTemplate}
         totalRecordsTemplate={totalRecordsTemplate}
       />
     );
@@ -48,7 +48,7 @@ PaginationPure.propTypes = {
   setPaginationValue: PropTypes.func.isRequired,
   paginationId: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
-  numberOfRowsTemplate: PropTypes.string,
+  rowsPerPageTemplate: PropTypes.string,
   totalRecordsTemplate: PropTypes.string,
 };
 

--- a/packages/visual-stack-redux/src/components/Pagination/tests/index.test.js
+++ b/packages/visual-stack-redux/src/components/Pagination/tests/index.test.js
@@ -48,7 +48,7 @@ describe('PaginationPure', () => {
   test('should forward the pagination value to visual stack pagination component', () => {
     // when
     const wrapper = mount(<PaginationPure
-      numberOfRowsTemplate={"numberOfRowsTemplate"}
+      rowsPerPageTemplate={"rowsPerPageTemplate"}
       totalRecordsTemplate={"totalRecordsTemplate"}
       {...defaultProps} />);
 
@@ -57,7 +57,7 @@ describe('PaginationPure', () => {
       page: paginationValue.page,
       numberOfRows,
       onChange: expect.any(Function),
-      numberOfRowsTemplate: "numberOfRowsTemplate",
+      rowsPerPageTemplate: "rowsPerPageTemplate",
       totalRecordsTemplate: "totalRecordsTemplate",
     });
   });

--- a/packages/visual-stack-redux/src/components/Pagination/tests/index.test.js
+++ b/packages/visual-stack-redux/src/components/Pagination/tests/index.test.js
@@ -47,13 +47,18 @@ describe('PaginationPure', () => {
 
   test('should forward the pagination value to visual stack pagination component', () => {
     // when
-    const wrapper = mount(<PaginationPure {...defaultProps} />);
+    const wrapper = mount(<PaginationPure
+      numberOfRowsTemplate={"numberOfRowsTemplate"}
+      totalRecordsTemplate={"totalRecordsTemplate"}
+      {...defaultProps} />);
 
     expect(wrapper.find(PaginationFromVS).props()).toEqual({
       rowsPerPage: paginationValue.rowsPerPage,
       page: paginationValue.page,
       numberOfRows,
       onChange: expect.any(Function),
+      numberOfRowsTemplate: "numberOfRowsTemplate",
+      totalRecordsTemplate: "totalRecordsTemplate",
     });
   });
 

--- a/packages/visual-stack/src/components/Pagination/index.js
+++ b/packages/visual-stack/src/components/Pagination/index.js
@@ -10,21 +10,21 @@ import './style.css';
 
 const validRowsPerPageValues = [10, 25, 50];
 
-const getRowsPerPageOptions = (numberOfRowsTemplate) => {
+const getRowsPerPageOptions = (rowsPerPageTemplate) => {
   return validRowsPerPageValues.map(value => {
     return {
       value: value,
-      label: numberOfRowsTemplate.replace("{0}", value)
+      label: rowsPerPageTemplate.replace("{0}", value)
     }
   })
 };
 
-const getRowsPerPageOption = (pageValue, numberOfRowsTemplate) =>
+const getRowsPerPageOption = (pageValue, rowsPerPageTemplate) =>
   pipe(
     groupBy(prop("value")),
     prop(pageValue),
     head
-  )(getRowsPerPageOptions(numberOfRowsTemplate));
+  )(getRowsPerPageOptions(rowsPerPageTemplate));
 
 const Pagination = ({
   numberOfRows,
@@ -32,7 +32,7 @@ const Pagination = ({
   page,
   onChange,
   className,
-  numberOfRowsTemplate = "{0} per page",
+  rowsPerPageTemplate = "{0} per page",
   totalRecordsTemplate = "{0} total records",
 }) => {
   const maxPage = Math.ceil(numberOfRows / rowsPerPage) || 1;
@@ -68,8 +68,8 @@ const Pagination = ({
       <div className="vs-rows-per-page-container">
         <Select
           name="rows-per-page"
-          value={getRowsPerPageOption(rowsPerPage, numberOfRowsTemplate)}
-          options={getRowsPerPageOptions(numberOfRowsTemplate)}
+          value={getRowsPerPageOption(rowsPerPage, rowsPerPageTemplate)}
+          options={getRowsPerPageOptions(rowsPerPageTemplate)}
           onChange={handleRowsPerPage}
         />
       </div>

--- a/packages/visual-stack/src/components/Pagination/index.js
+++ b/packages/visual-stack/src/components/Pagination/index.js
@@ -8,29 +8,23 @@ import { groupBy, head, prop, pipe } from 'ramda';
 import { withErrorBoundary } from '../ErrorBoundary';
 import './style.css';
 
-const defaultRowsPerPage = {
-  value: 10,
-  label: '10 per page',
+const validRowsPerPageValues = [10, 25, 50];
+
+const getRowsPerPageOptions = (numberOfRowsTemplate) => {
+  return validRowsPerPageValues.map(value => {
+    return {
+      value: value,
+      label: numberOfRowsTemplate.replace("{0}", value)
+    }
+  })
 };
 
-const rowsPerPageOptions = [
-  defaultRowsPerPage,
-  {
-    value: 25,
-    label: '25 per page',
-  },
-  {
-    value: 50,
-    label: '50 per page',
-  },
-];
-
-const rowsPerPageOptionsMap = groupBy(({ value }) => value)(rowsPerPageOptions);
-const getRowsPerPageOption = pageValue =>
+const getRowsPerPageOption = (pageValue, numberOfRowsTemplate) =>
   pipe(
+    groupBy(prop("value")),
     prop(pageValue),
     head
-  )(rowsPerPageOptionsMap);
+  )(getRowsPerPageOptions(numberOfRowsTemplate));
 
 const Pagination = ({
   numberOfRows,
@@ -38,6 +32,8 @@ const Pagination = ({
   page,
   onChange,
   className,
+  numberOfRowsTemplate = "{0} per page",
+  totalRecordsTemplate = "{0} total records",
 }) => {
   const maxPage = Math.ceil(numberOfRows / rowsPerPage) || 1;
 
@@ -63,13 +59,17 @@ const Pagination = ({
     }
   };
 
+  const getTranslatedNumberOfRecords = () => {
+    return totalRecordsTemplate.replace("{0}", numberOfRows);
+  };
+
   return (
     <div className={`vs-pagination ${className}`}>
       <div className="vs-rows-per-page-container">
         <Select
           name="rows-per-page"
-          value={getRowsPerPageOption(rowsPerPage)}
-          options={rowsPerPageOptions}
+          value={getRowsPerPageOption(rowsPerPage, numberOfRowsTemplate)}
+          options={getRowsPerPageOptions(numberOfRowsTemplate)}
           onChange={handleRowsPerPage}
         />
       </div>
@@ -89,7 +89,7 @@ const Pagination = ({
         </Button>
       </div>
       <div className="vs-pagination-total-records">
-        {numberOfRows} total records
+        {getTranslatedNumberOfRecords()}
       </div>
     </div>
   );

--- a/packages/visual-stack/src/components/Pagination/index.js
+++ b/packages/visual-stack/src/components/Pagination/index.js
@@ -39,7 +39,7 @@ const Pagination = ({
   onChange,
   className,
 }) => {
-  const maxPage = Math.ceil(numberOfRows / rowsPerPage);
+  const maxPage = Math.ceil(numberOfRows / rowsPerPage) || 1;
 
   const handleRowsPerPage = ({ value: nextRowsPerPage }) => {
     const paginationValue = {

--- a/packages/visual-stack/src/components/Pagination/tests/index.test.js
+++ b/packages/visual-stack/src/components/Pagination/tests/index.test.js
@@ -166,7 +166,7 @@ describe('Pagination', () => {
   it('should display the rows per page options', () => {
     // given
     const tester = createTesterWithOptions({
-      numberOfRowsTemplate: "display {0} of them"
+      rowsPerPageTemplate: "display {0} of them"
     });
 
     // then

--- a/packages/visual-stack/src/components/Pagination/tests/index.test.js
+++ b/packages/visual-stack/src/components/Pagination/tests/index.test.js
@@ -166,6 +166,17 @@ describe('Pagination', () => {
     expect(tester.getPagingInformation()).toEqual('1/5');
   });
 
+  it('should display paging information when empty', () => {
+    // given
+    const numberOfRows = 0;
+
+    // when
+    const tester = createTesterWithOptions({ numberOfRows });
+
+    // then
+    expect(tester.getPagingInformation()).toEqual('1/1');
+  });
+
   it('should display paging information that cant be divided evenly', () => {
     // given
     const numberOfRows = 52;

--- a/packages/visual-stack/src/components/Pagination/tests/index.test.js
+++ b/packages/visual-stack/src/components/Pagination/tests/index.test.js
@@ -115,6 +115,14 @@ describe('Pagination', () => {
     expect(tester.getTotalRecords()).toEqual(`27 total records`);
   });
 
+  it('should display total records using template', () => {
+    const tester = createTesterWithOptions({
+      numberOfRows: 27,
+      totalRecordsTemplate: "I have {0} entries"
+    });
+    expect(tester.getTotalRecords()).toEqual(`I have 27 entries`);
+  });
+
   it('should have default value for rows per page', () => {
     const tester = createTester();
     expect(tester.getRowsPerPageDropdownValue()).toEqual({
@@ -134,7 +142,7 @@ describe('Pagination', () => {
     });
   });
 
-  it('should display the rows per page options', () => {
+  it('should display the rows per page options using a template', () => {
     // given
     const tester = createTester();
 
@@ -151,6 +159,29 @@ describe('Pagination', () => {
       {
         value: 50,
         label: '50 per page',
+      },
+    ]);
+  });
+
+  it('should display the rows per page options', () => {
+    // given
+    const tester = createTesterWithOptions({
+      numberOfRowsTemplate: "display {0} of them"
+    });
+
+    // then
+    expect(tester.getRowsPerPageOptions()).toEqual([
+      {
+        value: 10,
+        label: 'display 10 of them',
+      },
+      {
+        value: 25,
+        label: 'display 25 of them',
+      },
+      {
+        value: 50,
+        label: 'display 50 of them',
       },
     ]);
   });

--- a/packages/visual-stack/src/components/SideNav/SideNav.css
+++ b/packages/visual-stack/src/components/SideNav/SideNav.css
@@ -273,7 +273,7 @@
 }
 
 .vs-sidenav .vs-sidenav-container.expanded ul {
-  max-height: 960px;
+  max-height: 100%;
 }
 
 .vs-sidenav.collapsed .vs-sidenav-header,

--- a/packages/visual-stack/src/components/SideNav/SideNav.css
+++ b/packages/visual-stack/src/components/SideNav/SideNav.css
@@ -273,7 +273,7 @@
 }
 
 .vs-sidenav .vs-sidenav-container.expanded ul {
-  max-height: 100%;
+  max-height: 1008px;
 }
 
 .vs-sidenav.collapsed .vs-sidenav-header,

--- a/packages/visual-stack/src/components/Table/DataTable/DataTable.css
+++ b/packages/visual-stack/src/components/Table/DataTable/DataTable.css
@@ -108,3 +108,7 @@
   width: 100%;
   justify-content: space-between;
 }
+
+.vs-data-table-no-data-label {
+  padding: 8px 16px;
+}

--- a/packages/visual-stack/src/components/Table/DataTable/DataTable.css
+++ b/packages/visual-stack/src/components/Table/DataTable/DataTable.css
@@ -32,7 +32,7 @@
 
 .vs-data-table-container .vs-tbody .vs-cell {
   min-height: 0;
-  padding: 4px 12px;
+  padding: 4px 8px;
 }
 
 .vs-data-table-container .vs-thead .vs-cell:first-child,

--- a/packages/visual-stack/src/components/Table/DataTable/index.js
+++ b/packages/visual-stack/src/components/Table/DataTable/index.js
@@ -93,6 +93,14 @@ const getDataWithPagination = (rowsPerPage, page) =>
     R.drop(rowsPerPage * (page - 1))
   );
 
+const NoDataLabel = ({label}) => {
+  return (
+    <div className="vs-data-table-no-data-label">
+      {label}
+    </div>
+  )
+};
+
 export const DataTable = ({
   caption = '',
   description = '',
@@ -107,6 +115,7 @@ export const DataTable = ({
   onClick,
   onSort,
   renderToolbar,
+  noDataLabel = "No data available.",
 }) => {
   const normalizedData = pagination
     ? getDataWithPagination(rowsPerPage, page)(data)
@@ -131,8 +140,11 @@ export const DataTable = ({
             )}
           </Tr>
         </THead>
-        <TBody>{normalizedData.map(generateRow({ onClick, columns }))}</TBody>
+        <TBody>
+          {normalizedData.map(generateRow({onClick, columns}))}
+        </TBody>
       </Table>
+      {normalizedData.length === 0 && <NoDataLabel label={noDataLabel}/>}
       {pagination && (
         <Pagination
           className="vs-table-pagination"

--- a/packages/visual-stack/src/components/Table/DataTable/index.js
+++ b/packages/visual-stack/src/components/Table/DataTable/index.js
@@ -116,6 +116,8 @@ export const DataTable = ({
   onSort,
   renderToolbar,
   noDataLabel = "No data available.",
+  numberOfRowsTemplate,
+  totalRecordsTemplate,
 }) => {
   const normalizedData = pagination
     ? getDataWithPagination(rowsPerPage, page)(data)
@@ -152,6 +154,8 @@ export const DataTable = ({
           rowsPerPage={rowsPerPage}
           page={page}
           onChange={onPageChange}
+          numberOfRowsTemplate={numberOfRowsTemplate}
+          totalRecordsTemplate={totalRecordsTemplate}
         />
       )}
     </TableContainer>

--- a/packages/visual-stack/src/components/Table/DataTable/index.js
+++ b/packages/visual-stack/src/components/Table/DataTable/index.js
@@ -116,7 +116,7 @@ export const DataTable = ({
   onSort,
   renderToolbar,
   noDataLabel = "No data available.",
-  numberOfRowsTemplate,
+  rowsPerPageTemplate,
   totalRecordsTemplate,
 }) => {
   const normalizedData = pagination
@@ -154,7 +154,7 @@ export const DataTable = ({
           rowsPerPage={rowsPerPage}
           page={page}
           onChange={onPageChange}
-          numberOfRowsTemplate={numberOfRowsTemplate}
+          rowsPerPageTemplate={rowsPerPageTemplate}
           totalRecordsTemplate={totalRecordsTemplate}
         />
       )}
@@ -179,4 +179,7 @@ DataTable.propTypes = {
   onSort: PropTypes.func,
   onClick: PropTypes.func,
   renderToolbar: PropTypes.func,
+  noDataLabel: PropTypes.string,
+  rowsPerPageTemplate: PropTypes.string,
+  totalRecordsTemplate: PropTypes.string,
 };

--- a/packages/visual-stack/src/components/Table/DataTable/tests/index.test.js
+++ b/packages/visual-stack/src/components/Table/DataTable/tests/index.test.js
@@ -76,6 +76,23 @@ describe('DataTable', () => {
   });
 
   describe('rows', () => {
+    it('should say "No data available." when there is no data', () => {
+      const wrapper = mount(
+        <DataTable data={[]} />
+      );
+      expect(wrapper.find('td')).toHaveLength(0);
+      expect(wrapper.find('div.vs-data-table-no-data-label').text()).toEqual("No data available.");
+    });
+
+    it('should use the overridden label when there is no data', () => {
+      const noDataLabel = "I have no data";
+      const wrapper = mount(
+        <DataTable data={[]} noDataLabel={noDataLabel}/>
+      );
+      expect(wrapper.find('td')).toHaveLength(0);
+      expect(wrapper.find('div.vs-data-table-no-data-label').text()).toEqual(noDataLabel);
+    });
+
     it('should render when there is data', () => {
       const data1 = 'data1';
       const data2 = 'data2';

--- a/packages/visual-stack/src/components/Table/DataTable/tests/index.test.js
+++ b/packages/visual-stack/src/components/Table/DataTable/tests/index.test.js
@@ -221,6 +221,32 @@ describe('DataTable', () => {
       });
     });
 
+    it('should pass translation templates to pagination', () => {
+      const onPageChange = jest.fn();
+
+      const numberOfRowsTemplate = "number of rows template";
+      const totalRecordsTemplate = "total records template";
+
+      const wrapper = mount(
+        <DataTable onPageChange={onPageChange}
+                   pagination
+                   numberOfRowsTemplate={numberOfRowsTemplate}
+                   totalRecordsTemplate={totalRecordsTemplate}/>
+      );
+      const paginationWrapper = wrapper.find('Pagination');
+      const paginationProps = paginationWrapper.props();
+      expect(paginationWrapper).toHaveLength(1);
+      expect(paginationProps).toEqual({
+        rowsPerPage: 25,
+        page: 1,
+        onChange: onPageChange,
+        className: 'vs-table-pagination',
+        numberOfRows: 0,
+        numberOfRowsTemplate: numberOfRowsTemplate,
+        totalRecordsTemplate: totalRecordsTemplate
+      });
+    });
+
     describe('Rendering Rows', () => {
       const group1 = range(1, 26);
       const group2 = range(26, 51);

--- a/packages/visual-stack/src/components/Table/DataTable/tests/index.test.js
+++ b/packages/visual-stack/src/components/Table/DataTable/tests/index.test.js
@@ -224,13 +224,13 @@ describe('DataTable', () => {
     it('should pass translation templates to pagination', () => {
       const onPageChange = jest.fn();
 
-      const numberOfRowsTemplate = "number of rows template";
+      const rowsPerPageTemplate = "number of rows template";
       const totalRecordsTemplate = "total records template";
 
       const wrapper = mount(
         <DataTable onPageChange={onPageChange}
                    pagination
-                   numberOfRowsTemplate={numberOfRowsTemplate}
+                   rowsPerPageTemplate={rowsPerPageTemplate}
                    totalRecordsTemplate={totalRecordsTemplate}/>
       );
       const paginationWrapper = wrapper.find('Pagination');
@@ -242,7 +242,7 @@ describe('DataTable', () => {
         onChange: onPageChange,
         className: 'vs-table-pagination',
         numberOfRows: 0,
-        numberOfRowsTemplate: numberOfRowsTemplate,
+        rowsPerPageTemplate: rowsPerPageTemplate,
         totalRecordsTemplate: totalRecordsTemplate
       });
     });


### PR DESCRIPTION
## Bug Fixes
- Pagination with 0 entries now correctly displays total pages
## New Feature
- Better handle empty DataTables with a new configurable message
- Add ability to change hard-coded text in Pagination for customization and translations
- Add ability for DataTables to change hard-coded text in Pagination
