### PR TITLE
Add onEscapeKeyUp function to Modal

### DIFF
--- a/packages/visual-stack-docs/src/containers/Components/Docs/modal.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/modal.js
@@ -59,7 +59,7 @@ const OpenModalButton = connect(
 
 /* s6:start */
 const OptionsModalDialog = ({ takeAction, closeModal }) => (
-  <M.Modal onBackgroundClick={closeModal}>
+  <M.Modal onBackgroundClick={closeModal} onEscapeKeyUp={closeModal}>
     <M.Dialog>
       <M.Content>
         <M.Header title="Header Title" />
@@ -131,9 +131,8 @@ export default () => (
             <Header>Modal Options</Header>
             <Body>
               <div>
-                The Modal component can be passed an 'onBackgroundClick' prop
-                (function) to define what should happen when a click occurs
-                outside the Modal. Typically this would be used to pass in the
+                The Modal component accepts optional props 'onBackgroundClick' and 'onEscapeKeyUp' to define what should happen when a click occurs
+                outside the Modal / when Escape is pressed. Typically these would be used to pass in the
                 'closeModal' function.
               </div>
               <OpenOptionsModalButton />

--- a/packages/visual-stack/src/components/Modal.js
+++ b/packages/visual-stack/src/components/Modal.js
@@ -8,17 +8,26 @@ const backgroundClick = (event, onBackgroundClick) => {
   }
 };
 
-export const Modal = ({ children, onBackgroundClick }) => (
-  <div
+const keyUpHandler = (onEscapeKeyUp, e) => {
+  if (e.keyCode === 27) {
+    if(onEscapeKeyUp) onEscapeKeyUp()
+  }
+};
+
+export const Modal = ({ children, onBackgroundClick, onEscapeKeyUp }) => {
+
+  document.addEventListener("keyup", (e) => keyUpHandler(onEscapeKeyUp, e));
+
+  return <div
     className="modal"
-    style={{ display: 'block' }}
+    style={{display: 'block'}}
     onClick={event =>
       onBackgroundClick ? backgroundClick(event, onBackgroundClick) : {}
     }
   >
     {children}
   </div>
-);
+};
 
 export const Header = ({ title, children }) => (
   <div className="modal-header">

--- a/packages/visual-stack/src/components/tests/Modal.test.js
+++ b/packages/visual-stack/src/components/tests/Modal.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import {Modal} from "../Modal";
+
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('Modal', () => {
+  it('should call onEscapeKeyUp when escape key pressed', () => {
+    //given
+
+    const map = {};
+    document.addEventListener = jest.fn((event, cb) => {
+      map[event] = cb;
+    });
+
+    const fakeKeyFunction = jest.fn();
+    const wrapper = mount(<Modal onEscapeKeyUp={fakeKeyFunction} />);
+
+    //when
+    map.keyup({ keyCode: 27 });
+
+    //then
+    expect(fakeKeyFunction).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Similar to onBackgroundClick, a new prop intended to be used for closing the Modal when the Escape key is pressed