### PR TITLE
SelectField passes react-select props only to react-select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.2
+## Bug Fix
+- SelectField passes react-select props only to react-select
+
 # 5.1.1
 ## Bug Fix
 - Additional Popover props are now being passed to the correct sub-component 

--- a/packages/visual-stack/src/components/Form.js
+++ b/packages/visual-stack/src/components/Form.js
@@ -192,6 +192,13 @@ export const SelectField = ({
   value,
   onChange,
   onBlur,
+  noOptionsMessage,
+  isClearable,
+  isDisabled,
+  isMulti,
+  isSearchable,
+  autoFocus,
+  placeholder,
   ...otherProps
 }) => (
   <Field label={label} error={error} help={help} {...otherProps}>
@@ -202,6 +209,13 @@ export const SelectField = ({
         value={value}
         onChange={onChange}
         onBlur={onBlur}
+        autoFocus={autoFocus}
+        noOptionsMessage={noOptionsMessage}
+        isClearable={isClearable}
+        isDisabled={isDisabled}
+        isMulti={isMulti}
+        isSearchable={isSearchable}
+        placeholder={placeholder}
         {...otherProps}
       />
     </FieldContent>


### PR DESCRIPTION
react-select props passed to SelectField - results in react throwing warning logs. Passing react-select props only to react-select with this change.