### PR TITLE
Make SideNav max-height fit-content instead of fixed height

### DIFF
--- a/packages/visual-stack/src/components/SideNav/SideNav.css
+++ b/packages/visual-stack/src/components/SideNav/SideNav.css
@@ -273,7 +273,7 @@
 }
 
 .vs-sidenav .vs-sidenav-container.expanded ul {
-  max-height: 1056px;
+  max-height: fit-content;
 }
 
 .vs-sidenav.collapsed .vs-sidenav-header,


### PR DESCRIPTION
This fixes the docs to show all components in the sidenav.