### PR TITLE
omit VS props from being passed to SideNav ul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.7.8
+## Bug Fix
+- SideNav: omit VS props from being passed to SideNav ul to avoid react console warnings
+
 # 6.7.7
 ## Bug Fix
 - ChoiceInput: Separate onClick prop for ChoiceInput and pass it only to actual Input, so the handler runs only once

--- a/packages/visual-stack/src/components/SideNav/SideNav.js
+++ b/packages/visual-stack/src/components/SideNav/SideNav.js
@@ -58,6 +58,10 @@ class SideNavP extends React.Component {
       ...restProps
     } = this.props;
 
+    const restPropsForDOMElements = R.omit(
+      ['initializedCollapsed', 'logoBackground', 'toggleSideNav', 'matches'],
+      restProps
+    );
     const toggle = () => onClick(!collapsed);
     const capAppName = appName ? appName.toUpperCase() : '';
     const userMenuWithColor = userMenu
@@ -65,7 +69,7 @@ class SideNavP extends React.Component {
       : null;
     return (
       <ul
-        {...restProps}
+        {...restPropsForDOMElements}
         className={'vs-sidenav' + (collapsed ? ' collapsed' : ' active')}
       >
         <li className="vs-sideNav-left-logo">

--- a/packages/visual-stack/src/components/SideNav/tests/index.test.js
+++ b/packages/visual-stack/src/components/SideNav/tests/index.test.js
@@ -45,6 +45,26 @@ describe('SideNav', () => {
     );
   });
 
+  test('should omit VS properties from propagating to DOM ul', () => {
+    const wrapper = mount(
+      <SideNav
+        onClick={() => {}}
+        userMenu={<div />}
+        initializedCollapsed={false}
+        logoBackground={<div />}
+        toggleSideNav={() => {}}
+        matches={false}
+      />
+    );
+    wrapper.update();
+    const ul = wrapper.find('ul');
+    expect(ul).toHaveLength(1);
+    expect(ul.prop('initializedCollapsed')).toBeUndefined();
+    expect(ul.prop('logoBackground')).toBeUndefined();
+    expect(ul.prop('matches')).toBeUndefined();
+    expect(ul.prop('toggleSideNav')).toBeUndefined();
+  });
+
   describe('Header', () => {
     test('should render with children', () => {
       const wrapper = mount(
@@ -89,7 +109,7 @@ describe('SideNav', () => {
   describe('Link', () => {
     test('should render with children and default Icon', () => {
       const wrapper = mount(
-        <Link inLinkGroup={false}>
+        <Link>
           <a href="mock link for React Router">
             <span>Label without Text</span>
           </a>


### PR DESCRIPTION
omit VS props from being passed to SideNav ul so that we can stop react warnings