### PR TITLE
Add ability for tabs to render lazily

### DIFF
--- a/packages/visual-stack-docs/src/containers/Components/Docs/tablayout.js
+++ b/packages/visual-stack-docs/src/containers/Components/Docs/tablayout.js
@@ -145,6 +145,41 @@ export default () => (
                       </div>
                     </Body>
                   </Panel>
+                  <Panel>
+                    <Header>
+                      <div>
+                        TabLayout with lazy prop renders tab content only when
+                        selected
+                      </div>
+                    </Header>
+                    <Body>
+                      <Snippet tag="s8" src={snippets} />
+                      <DivWithBorder>
+                        {/* s8:start */}
+                        <TabLayout lazy tabLayoutId="tabLayout4">
+                          <Tab
+                            label={<TabLabelContent>Tab 1</TabLabelContent>}
+                            renderContent={() => (
+                              <TabContent>Tab Content 1</TabContent>
+                            )}
+                          />
+                          <Tab
+                            label={<TabLabelContent>Tab 2</TabLabelContent>}
+                            renderContent={() => (
+                              <TabContent>Tab Content 2</TabContent>
+                            )}
+                          />
+                          <Tab
+                            label={<TabLabelContent>Tab 3</TabLabelContent>}
+                            renderContent={() => (
+                              <TabContent>Tab Content 3</TabContent>
+                            )}
+                          />
+                        </TabLayout>
+                        {/* s8:end */}
+                      </DivWithBorder>
+                    </Body>
+                  </Panel>
                 </TabContent>
               }
             />

--- a/packages/visual-stack-redux/CHANGELOG.md
+++ b/packages/visual-stack-redux/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Upcoming
+
+## New Features
+
+- Tabs can now render lazily.
+
 # 0.0.12 (January 2, 2017)
 
 ## New Features

--- a/packages/visual-stack-redux/src/components/TabLayout.js
+++ b/packages/visual-stack-redux/src/components/TabLayout.js
@@ -57,6 +57,7 @@ export class InternalTabLayout extends Component {
           R.lensPath([this.props.tabLayoutId, 'index']),
           this.props.tabLayouts
         )}
+        lazy={this.props.lazy}
       >
         {this.props.children}
       </BaseTabLayout>

--- a/packages/visual-stack-redux/test/components/TabLayout.test.js
+++ b/packages/visual-stack-redux/test/components/TabLayout.test.js
@@ -27,6 +27,7 @@ describe('TabLayout', () => {
     onTabClick: () => {},
     tabLayouts: { ID123: { index: 0 } },
     selectTab: () => {},
+    lazy: true,
     ...override,
   });
 

--- a/packages/visual-stack/src/components/TabLayout/index.js
+++ b/packages/visual-stack/src/components/TabLayout/index.js
@@ -16,7 +16,13 @@ export class TabLayout extends React.Component {
   }
 
   render() {
-    const { floatingHeader, headerHeight, headerWidth } = this.props;
+    const {
+      floatingHeader,
+      headerHeight,
+      headerWidth,
+      lazy,
+      tabLayoutId,
+    } = this.props;
     const children = toArray(this.props.children);
     const tabs = R.filter(R.identity, children);
     const labelMap = tabs.map((tab, index) => {
@@ -35,9 +41,14 @@ export class TabLayout extends React.Component {
       );
     });
     const contentMap = tabs.map((tab, index) => {
+      const selected = this.isSelected(index);
+      if (lazy && !selected) {
+        return null;
+      }
       return (
-        <div key={index} hidden={!this.isSelected(index)}>
-          {tab.props.content}
+        <div key={index} hidden={!selected}>
+          {tab.props.content ||
+            (tab.props.renderContent ? tab.props.renderContent() : null)}
         </div>
       );
     });


### PR DESCRIPTION
1. Adds optional 'lazy' prop to TabLayout, making it render tab content only when the tab is selected.
2. Adds optional 'renderContent' prop to Tab, taking a function to render the content.