### PR TITLE
Prevent the sidenav icons from looking too much apart when the sidenav is collapsed and the user is using the expanded property

### DIFF
--- a/packages/visual-stack/src/components/SideNav/LinkGroup.js
+++ b/packages/visual-stack/src/components/SideNav/LinkGroup.js
@@ -25,7 +25,7 @@ export class LinkGroup extends React.Component {
   render() {
     const classes =
       `${this.props.className || ''} vs-sidenav-entry vs-sidenav-container` +
-      (this.props.expanded ? ' expanded' : '');
+      (this.props.expanded && !this.props.collapsed ? ' expanded' : '');
     const expandRow = () => {
       this.props.onClick(!this.props.expanded, this.props.label);
       if (this.props.expanded) {


### PR DESCRIPTION
### Problem
The expanded property if LinkGroup is useful to always have visible the items of a menu if it only has just a few items, the problem is that if you set expanded to true and the sidebar is collapsed it still shows all the vertical empty space that is used for the menu items.

<img width="689" alt="sidenav-01" src="https://user-images.githubusercontent.com/19540257/121712123-022d4a00-caa1-11eb-959d-369587536eb4.png">

<img width="624" alt="sidenav-02" src="https://user-images.githubusercontent.com/19540257/121712963-ee361800-caa1-11eb-9758-bc0d0297c4e4.png">

### Solution

Prevents the sidenav icons from looking too much apart when the sidenav is collapsed. This does the task by not adding the .expanded class if the SideNav is collapsed

