### PR TITLE
CategoryLabel.js: omit properties that doesn't exist in DOM

### DIFF
--- a/packages/visual-stack/src/components/SideNav/CategoryLabel.js
+++ b/packages/visual-stack/src/components/SideNav/CategoryLabel.js
@@ -2,9 +2,11 @@ import React from 'react';
 import './SideNav.css';
 
 export const CategoryLabel = ({ children, collapsed, ...restProps }) => {
+  const domProps = R.omit(['dispatch'], restProps);
+
   return (
     !collapsed && (
-      <div {...restProps} className="vs-category-label">
+      <div {...domProps} className="vs-category-label">
         {children}
       </div>
     )


### PR DESCRIPTION
Omit properties that doesn't belong in dom nodes to avoid errors in DevTools